### PR TITLE
Filter option for raid cursor and target unit frames (unit hotkeys)

### DIFF
--- a/ConsolePort/Controller/EasyMotion.lua
+++ b/ConsolePort/Controller/EasyMotion.lua
@@ -346,6 +346,7 @@ function EM:OnNewBindings(bindings)
 end
 
 function EM:OnNewAttributes()
+  self:SetAttribute('FrameExcludeStrings', db('raidCursorFrameFilters'))
 	self:SetAttribute('unitpool', (db('unitHotkeyPool') or ''):gsub(';', '\n'))
 	self:SetAttribute('ghostMode', db('unitHotkeyGhostMode'))
 	self:SetAttribute('ignorePlayer', db('unitHotkeyIgnorePlayer'))
@@ -395,7 +396,18 @@ function EM:RefreshUnitFrames(current)
 		stack = {self:GetParent():GetChildren()}
 	elseif current:IsVisible() then
 		local unit = current:GetAttribute('unit')
-		if unit then
+
+		local name = current:GetName()
+		local excludeFrame = false;
+		if name then
+			for token in string.gmatch(self:GetAttribute('FrameExcludeStrings'), "[^%s]+") do
+				if string.find(name,token) then
+					excludeFrame = true;
+				end
+			end
+		end
+
+		if unit and not excludeFrame then
 			self:AddFrameForUnit(current, unit)
 		end
 		stack = {current:GetChildren()}

--- a/ConsolePort/Model/Data/Variables.lua
+++ b/ConsolePort/Model/Data/Variables.lua
@@ -491,4 +491,11 @@ db:Register('Variables', {
 		note = BLUE_FONT_COLOR:WrapTextInColorCode('node') .. ' is the current frame under scrutinization.';
 		advd = true;
 	};
+	raidCursorFrameFilters = {String(nil);
+		head = ADVANCED_OPT;
+		sort = 8;
+		name = 'Raid Cursor Frame Filters';
+		desc = 'List of strings (space delmited) to check frame names for to exclude from raid cursor and target unit frames feature. Use /fstack to identify frame names and /reload for changes to take effect';
+		note = 'vuhdo fix: BgBarIcBarHlBarIc';
+	};
 })  --------------------------------------------------------------------------------------------------------

--- a/ConsolePort/View/Cursors/Raid.lua
+++ b/ConsolePort/View/Cursors/Raid.lua
@@ -46,7 +46,17 @@ Cursor:CreateEnvironment({
 			local unit = node:GetAttribute('unit')
 			local action = node:GetAttribute('action')
 
-			if unit and not action then
+			local name = node:GetName()
+			local excludeFrame = false;
+			if name then
+			  for token in string.gmatch(self:GetAttribute('FrameExcludeStrings'), "[^%s]+") do
+				  if string.find(name,token) then
+					  excludeFrame = true;
+				  end
+		 	  end
+		  end
+			
+			if unit and not action and not excludeFrame then
 				if node:GetRect() and self:Run(filter) then
 					NODES[node] = true;
 					CACHE[node] = true;
@@ -181,6 +191,7 @@ Cursor:CreateEnvironment({
 function Cursor:OnDataLoaded()
 	local modifier = db('raidCursorModifier')
 	modifier = modifier:match('<none>') and '' or modifier..'-';
+	self:SetAttribute('FrameExcludeStrings', db('raidCursorFrameFilters'))
 	self:SetAttribute('noroute', db('raidCursorDirect'))
 	self:SetAttribute('navmodifier', modifier)
 	self:SetAttribute('filter', 'return ' .. (db('raidCursorFilter') or 'true') .. ';') 


### PR DESCRIPTION
Adds an advanced option to filter unit frames by partial frame name. Works on both raid cursor and target unit frames.

So far seems to work for filtering out the "extra" frames in vuhdo and excluding raven buff/debuff frames.