### PR TITLE
Add support for Wrath Classic in version

### DIFF
--- a/ConsolePort/Utils/Const.lua
+++ b/ConsolePort/Utils/Const.lua
@@ -4,6 +4,7 @@
 -- return true or nil (nil for dynamic table insertions)
 CPAPI.IsClassicEraVersion = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC or nil;
 CPAPI.IsClassicVersion    = WOW_PROJECT_ID == WOW_PROJECT_MISTS_CLASSIC or nil;
+CPAPI.IsWrathVersion      = WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC or nil;
 CPAPI.IsRetailVersion     = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE or nil;
 CPAPI.IsAnniVersion       = WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC or nil;
 

--- a/ConsolePort_Bar/Controller/Blizzard/Classic.lua
+++ b/ConsolePort_Bar/Controller/Blizzard/Classic.lua
@@ -1,5 +1,5 @@
 -- Credit: https://github.com/Nevcairiel/Bartender4/blob/master/HideBlizzard.lua
-if not CPAPI.IsAnniVersion then return end;
+if not (CPAPI.IsAnniVersion or CPAPI.IsWrathVersion) then return end;
 local _, env = ...;
 
 local function hideEditModeFrame(frame, clearEvents)

--- a/ConsolePort_Bar/Controller/Blizzard/ClassicEra.lua
+++ b/ConsolePort_Bar/Controller/Blizzard/ClassicEra.lua
@@ -1,5 +1,5 @@
 -- Credit: https://github.com/Nevcairiel/Bartender4/blob/master/HideBlizzardClassic.lua
-if not CPAPI.IsClassicEraVersion and not CPAPI.IsClassicVersion then return end;
+if not CPAPI.IsClassicEraVersion and not CPAPI.IsClassicVersion and not CPAPI.IsWrathVersion then return end;
 local _, env = ...;
 
 local function reparent(frame)

--- a/ConsolePort_Menu/Model/Buttons.lua
+++ b/ConsolePort_Menu/Model/Buttons.lua
@@ -2,7 +2,7 @@ local _, env = ...;
 ---------------------------------------------------------------
 local ICON = GenerateClosure(format, [[Interface\ICONS\%s]]);
 local IsRetailVersion      = CPAPI.IsRetailVersion or nil;
-local IsClassicGameVersion = CPAPI.IsClassicVersion or CPAPI.IsClassicEraVersion or CPAPI.IsAnniVersion or nil;
+local IsClassicGameVersion = CPAPI.IsClassicVersion or CPAPI.IsClassicEraVersion or CPAPI.IsAnniVersion or CPAPI.IsWrathVersion or nil;
 
 local GenerateFlatClosure = GenerateFlatClosure or function(...)
 	local closure = GenerateClosure(...)
@@ -167,10 +167,7 @@ env.Buttons = {}; _ = function(data) tinsert(env.Buttons, data) end;
 	end;
 } end;
 
----------------------------------------------------------------
---[[ Keyring ]] if CPAPI.IsClassicEraVersion or CPAPI.IsAnniVersion and KeyRingButton then _{
----------------------------------------------------------------
-	text  = KEYRING;
+	--[[ Keyring ]] if (CPAPI.IsClassicEraVersion or CPAPI.IsAnniVersion or CPAPI.IsWrathVersion) and KeyRingButton then _{
 	img   = [[Interface\ContainerFrame\KeyRing-Bag-Icon]];
 	ref   = KeyRingButton;
 } end;
@@ -207,7 +204,7 @@ env.Buttons = {}; _ = function(data) tinsert(env.Buttons, data) end;
 	img   = [[Interface\LFGFRAME\UI-LFG-PORTRAIT]];
 	ref   = LFDMicroButton or LFGMicroButton;
 	click = CPAPI.IsClassicVersion and GenerateFlatClosure(PVEFrame_ToggleFrame);
-	OnLoad = (CPAPI.IsClassicEraVersion or CPAPI.IsAnniVersion) and function(self)
+	OnLoad = (CPAPI.IsClassicEraVersion or CPAPI.IsAnniVersion or CPAPI.IsWrathVersion) and function(self)
 		self.OnLoad = nil;
 		EventUtil.ContinueOnAddOnLoaded('Blizzard_GroupFinder_VanillaStyle', function()
 			env.db:RunSafe(function()


### PR DESCRIPTION
Hi @seblindfors, thanks for the classic support in the recent release, however, the new release is not compatible with Wrath Classic, which is the wow version of titan reforged server. 

Hope you can review and merge this PR, the content is quite straightforward, just applying everything "classic" to "Wrath classic".