### PR TITLE
Fix recurrent error in the targeting LUA preventing current play

### DIFF
--- a/ConsolePort/Controller/Targeting.lua
+++ b/ConsolePort/Controller/Targeting.lua
@@ -39,8 +39,7 @@ end
 local function IsTooltipAvailable()
 	return not ConsolePort:IsCursorActive()
 		and (( GameTooltip:IsOwned(UIParent) or anchor and GameTooltip:IsOwned(anchor) )
-		or not GameTooltip:IsVisible()
-		or GameTooltip:GetAlpha() < 1);
+		or not GameTooltip:IsVisible());
 end
 
 local function IsTooltipOwned(unit, guid)


### PR DESCRIPTION
GameToolTIp.GetAlpha() is constantly being hidden by the game creating continuous errors in the current version that you can't compare an hidden value.

Error message it fixes:
Message: ...nterface/AddOns/ConsolePort/Controller/Targeting.lua:43: attempt to compare a secret number value (tainted by 'ConsolePort')
Time: Wed Mar 25 11:59:56 2026


- Removed GameTooltip:GetAlpha()