### PR TITLE
Support for Titan Reforged (IsWrathVersion)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ConsolePort/Libs/External/*
 ConsolePort_Config/Libs/*
 !ConsolePort/Libs/External/__manifest.xml
 !ConsolePort_Config/Libs/Libs.xml
+wow-ui-source

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -867,7 +867,7 @@ local text = env.L.NAME_TOGGLE_BINDINGS;
 The `.toc` supports multiple WoW versions via comma-separated interface numbers:
 
 ```
-## Interface: 120001, 120000, 50503, 38000, 20505, 11508
+## Interface: 120001, 120000, 50503, 38010, 20505, 11508
 ```
 
 ### Version Flags

--- a/ConsolePort/ConsolePort.toc
+++ b/ConsolePort/ConsolePort.toc
@@ -1,4 +1,4 @@
-## Interface: 120001, 120000, 50503, 38000, 20505, 11508
+## Interface: 120001, 120000, 50503, 38010, 20505, 11508
 ## IconTexture: Interface\AddOns\ConsolePort\Assets\Textures\Logo\CP_Thumb
 ## Title: Console Port
 ## Notes: Gamepad addon suite

--- a/ConsolePort/Controller/Input.lua
+++ b/ConsolePort/Controller/Input.lua
@@ -273,12 +273,11 @@ end
 
 function InputMixin:EmulateFrontend(click, state, script, ...)
 	if click:IsEnabled() then
-		local emubutton = self:GetAttribute('emubutton') or 'LeftButton';
-		if ConsolePort:ProcessInterfaceClickEvent(script, click, state, emubutton) then
+		if ConsolePort:ProcessInterfaceClickEvent(script, click, state) then
 			self.postreset = self:GetAttribute(CPAPI.ActionTypeRelease)
 			self:SetAttribute(CPAPI.ActionTypeRelease, nil)
 		end
-		ExecuteFrameScript(click, script, emubutton, ...)
+		ExecuteFrameScript(click, script, ...)
 		return click:SetButtonState(state)
 	end
 end

--- a/ConsolePort/Controller/Input.lua
+++ b/ConsolePort/Controller/Input.lua
@@ -167,7 +167,6 @@ end
 ---------------------------------------------------------------
 function InputMixin:SetOverride(data)
 	self[data.isPriority and 1 or 2] = data
-	self:SetAttribute('emubutton', data.button or 'LeftButton')
 	if data.attributes then
 		for attribute, value in pairs(data.attributes) do
 			self:SetAttribute(attribute, value)

--- a/ConsolePort/Controller/Input.lua
+++ b/ConsolePort/Controller/Input.lua
@@ -167,6 +167,7 @@ end
 ---------------------------------------------------------------
 function InputMixin:SetOverride(data)
 	self[data.isPriority and 1 or 2] = data
+	self:SetAttribute('emubutton', data.button or 'LeftButton')
 	if data.attributes then
 		for attribute, value in pairs(data.attributes) do
 			self:SetAttribute(attribute, value)
@@ -230,7 +231,7 @@ end
 InputMixin.timer = 0;
 
 function InputMixin:OnLoad(id)
-	if CPAPI.IsRetailVersion or CPAPI.IsAnniVersion then
+	if CPAPI.IsRetailVersion or CPAPI.IsAnniVersion or CPAPI.IsWrathVersion then
 		self:RegisterForClicks('AnyUp', 'AnyDown')
 		self:SetAttribute(CPAPI.ActionPressAndHold, true)
 	end
@@ -272,11 +273,12 @@ end
 
 function InputMixin:EmulateFrontend(click, state, script, ...)
 	if click:IsEnabled() then
-		if ConsolePort:ProcessInterfaceClickEvent(script, click, state) then
+		local emubutton = self:GetAttribute('emubutton') or 'LeftButton';
+		if ConsolePort:ProcessInterfaceClickEvent(script, click, state, emubutton) then
 			self.postreset = self:GetAttribute(CPAPI.ActionTypeRelease)
 			self:SetAttribute(CPAPI.ActionTypeRelease, nil)
 		end
-		ExecuteFrameScript(click, script, ...)
+		ExecuteFrameScript(click, script, emubutton, ...)
 		return click:SetButtonState(state)
 	end
 end

--- a/ConsolePort/Utils/Const.lua
+++ b/ConsolePort/Utils/Const.lua
@@ -13,7 +13,7 @@ CPAPI.IsAnniVersion       = WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSI
 ---------------------------------------------------------------
 CPAPI.ExtraActionButtonID = (ExtraActionButton1 or {}).action or CPAPI.IsRetailVersion and 217 or 169;
 
-CPAPI.ActionTypeRelease   = (CPAPI.IsRetailVersion or CPAPI.IsAnniVersion) and 'typerelease' or 'type';
+CPAPI.ActionTypeRelease   = (CPAPI.IsRetailVersion or CPAPI.IsAnniVersion or CPAPI.IsWrathVersion or CPAPI.IsClassicVersion) and 'typerelease' or 'type';
 CPAPI.ActionTypePress     = 'type';
 CPAPI.ActionPressAndHold  = 'pressAndHoldAction';
 CPAPI.ActionUseOnKeyDown  = 'useOnKeyDown';

--- a/ConsolePort/Utils/Const.lua
+++ b/ConsolePort/Utils/Const.lua
@@ -13,7 +13,7 @@ CPAPI.IsAnniVersion       = WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSI
 ---------------------------------------------------------------
 CPAPI.ExtraActionButtonID = (ExtraActionButton1 or {}).action or CPAPI.IsRetailVersion and 217 or 169;
 
-CPAPI.ActionTypeRelease   = (CPAPI.IsRetailVersion or CPAPI.IsAnniVersion or CPAPI.IsWrathVersion or CPAPI.IsClassicVersion) and 'typerelease' or 'type';
+CPAPI.ActionTypeRelease   = (CPAPI.IsRetailVersion or CPAPI.IsAnniVersion or CPAPI.IsWrathVersion) and 'typerelease' or 'type';
 CPAPI.ActionTypePress     = 'type';
 CPAPI.ActionPressAndHold  = 'pressAndHoldAction';
 CPAPI.ActionUseOnKeyDown  = 'useOnKeyDown';

--- a/ConsolePort_Bar/ConsolePort_Bar.toc
+++ b/ConsolePort_Bar/ConsolePort_Bar.toc
@@ -1,4 +1,4 @@
-## Interface: 120001, 120000, 50503, 38000, 20505, 11508
+## Interface: 120001, 120000, 50503, 38010, 20505, 11508
 ## IconTexture: Interface\AddOns\ConsolePort\Assets\Textures\Logo\CP_Thumb
 ## Title: Console Port |cff69ccf0Action Bar|r
 ## Notes: Action bar module

--- a/ConsolePort_Bar/Controller/Blizzard/ClassicEra.lua
+++ b/ConsolePort_Bar/Controller/Blizzard/ClassicEra.lua
@@ -1,5 +1,5 @@
 -- Credit: https://github.com/Nevcairiel/Bartender4/blob/master/HideBlizzardClassic.lua
-if not CPAPI.IsClassicEraVersion and not CPAPI.IsClassicVersion and not CPAPI.IsWrathVersion then return end;
+if not CPAPI.IsClassicEraVersion and not CPAPI.IsClassicVersion then return end;
 local _, env = ...;
 
 local function reparent(frame)

--- a/ConsolePort_Bar/View/Toolbar/Toolbar.lua
+++ b/ConsolePort_Bar/View/Toolbar/Toolbar.lua
@@ -297,127 +297,18 @@ end
 ---------------------------------------------------------------
 local PopoutFrame = CreateFromMixins(CPToolbarSixSliceInverterMixin)
 ---------------------------------------------------------------
-local IS_DYNAMIC_MICROMENU = CPAPI.IsRetailVersion or CPAPI.IsWrathVersion;
-local EnsureMicroMenuLoaded = nop;
-local CollectMicroButtons = function(self)
-	self.MicroButtons = {};
-	for i, name in ipairs(MICRO_BUTTONS or {}) do
-		local button = _G[name];
-		if button then
-			self.MicroButtons[button] = button.layoutIndex or i;
-		end
-	end
-end;
-
-if IS_DYNAMIC_MICROMENU then
-	local WRATH_MICRO_BUTTONS = {
-		'CharacterMicroButton';
-		'SpellbookMicroButton';
-		'TalentMicroButton';
-		'AchievementMicroButton';
-		'QuestLogMicroButton';
-		'SocialsMicroButton';
-		'GuildMicroButton';
-		'CollectionsMicroButton';
-		'PVPMicroButton';
-		'LFGMicroButton';
-		'MainMenuMicroButton';
-		'HelpMicroButton';
-	};
-	local RETAIL_MICRO_BUTTONS = {
-		'CharacterMicroButton';
-		'ProfessionMicroButton';
-		'PlayerSpellsMicroButton';
-		'AchievementMicroButton';
-		'QuestLogMicroButton';
-		'HousingMicroButton';
-		'GuildMicroButton';
-		'LFDMicroButton';
-		'CollectionsMicroButton';
-		'EJMicroButton';
-		'HelpMicroButton';
-		'StoreMicroButton';
-		'MainMenuMicroButton';
-	};
-
-	EnsureMicroMenuLoaded = function()
-		if not MicroMenu and not CPAPI.IsAddOnLoaded('Blizzard_MicroMenu') then
-			UIParentLoadAddOn('Blizzard_MicroMenu')
-		end
-	end;
-
-	CollectMicroButtons = function(self)
-		self.MicroButtons = {};
-
-		if MicroMenu then
-			for _, button in ipairs({MicroMenu:GetChildren()}) do
-				if button.layoutIndex then
-					self.MicroButtons[button] = button.layoutIndex;
-				end
-			end
-			if next(self.MicroButtons) then return end;
-
-			if MicroMenu.GenerateButtonInfos then
-				for i, info in ipairs(MicroMenu:GenerateButtonInfos() or {}) do
-					local button = info and info.button;
-					if button then
-						self.MicroButtons[button] = button.layoutIndex or i;
-					end
-				end
-				if next(self.MicroButtons) then return end;
-			end
-		end
-
-		local fallbackList = CPAPI.IsRetailVersion and RETAIL_MICRO_BUTTONS or WRATH_MICRO_BUTTONS;
-		for i, name in ipairs(fallbackList) do
-			local button = _G[name];
-			if button then
-				self.MicroButtons[button] = i;
-			end
-		end
-
-		if not self.didWarnFallbackMicroMenu then
-			self.didWarnFallbackMicroMenu = true;
-			CPAPI.Log('Toolbar micromenu fallback path active (%s list).', CPAPI.IsRetailVersion and 'Retail' or 'Wrath')
-		end
-	end;
-end
-
-function PopoutFrame:RefreshMicroButtons()
-	CollectMicroButtons(self)
-end
-
-function PopoutFrame:HookMicroMenu()
-	if self.microMenuHooked then return end;
-	if not MicroMenu or not MicroMenu.OverrideMicroMenuPosition then return end;
-	hooksecurefunc(MicroMenu, 'OverrideMicroMenuPosition', GenerateClosure(self.OnOverrideMicroMenuPosition, self))
-	self.microMenuHooked = true;
-end
-
-function PopoutFrame:OnEvent(event, ...)
-	if event == 'ADDON_LOADED' then
-		local addon = ...;
-		if addon ~= 'Blizzard_MicroMenu' then return end;
-	end
-	if event == 'ADDON_LOADED' or event == 'PLAYER_ENTERING_WORLD' then
-		self:HookMicroMenu()
-		self:RefreshMicroButtons()
-		if self.props and self.props.micromenu then
-			self:MoveMicroButtons()
-		end
-	end
-end
-
 function PopoutFrame:OnLoad()
 	Mixin(self.Eye, Eye):OnLoad()
 	Mixin(self.Config, Config):OnLoad()
 	Mixin(self.ExitVehicle, ExitVehicle):OnLoad()
-	self:RegisterEvent('ADDON_LOADED')
-	self:RegisterEvent('PLAYER_ENTERING_WORLD')
-	self:SetScript('OnEvent', self.OnEvent)
-	EnsureMicroMenuLoaded()
 
-	self:RefreshMicroButtons()
+	self.MicroButtons = {};
+	for i, name in ipairs(MICRO_BUTTONS) do
+		local button = _G[name];
+		if button then
+			self.MicroButtons[button] = CPAPI.IsRetailVersion and button.layoutIndex or i;
+		end
+	end
 
 	self:SlideOut()
 	RunNextFrame(function()
@@ -427,7 +318,6 @@ function PopoutFrame:OnLoad()
 	if OverrideMicroMenuPosition then
 		hooksecurefunc('OverrideMicroMenuPosition', GenerateClosure(self.OnOverrideMicroMenuPosition, self))
 	end
-	self:HookMicroMenu()
 	if UpdateMicroButtonsParent then
 		hooksecurefunc('UpdateMicroButtonsParent', GenerateClosure(self.OnUpdateMicroButtonsParent, self))
 	end
@@ -460,7 +350,6 @@ function PopoutFrame:Layout()
 end
 
 function PopoutFrame:MoveMicroButtons()
-	self:RefreshMicroButtons()
 	self.Divider1:SetShown(self.props.micromenu)
 	if not self.props.micromenu then return end;
 	for button, index in pairs(self.MicroButtons) do
@@ -518,7 +407,6 @@ end
 function PopoutFrame:OnOverrideMicroMenuPosition(...)
 	if not self.props.micromenu then return end;
 	if not MicroMenu then return end;
-	self:RefreshMicroButtons()
 	for button in pairs(self.MicroButtons) do
 		button:SetParent(MicroMenu)
 	end

--- a/ConsolePort_Bar/View/Toolbar/Toolbar.lua
+++ b/ConsolePort_Bar/View/Toolbar/Toolbar.lua
@@ -297,18 +297,127 @@ end
 ---------------------------------------------------------------
 local PopoutFrame = CreateFromMixins(CPToolbarSixSliceInverterMixin)
 ---------------------------------------------------------------
+local IS_DYNAMIC_MICROMENU = CPAPI.IsRetailVersion or CPAPI.IsWrathVersion;
+local EnsureMicroMenuLoaded = nop;
+local CollectMicroButtons = function(self)
+	self.MicroButtons = {};
+	for i, name in ipairs(MICRO_BUTTONS or {}) do
+		local button = _G[name];
+		if button then
+			self.MicroButtons[button] = button.layoutIndex or i;
+		end
+	end
+end;
+
+if IS_DYNAMIC_MICROMENU then
+	local WRATH_MICRO_BUTTONS = {
+		'CharacterMicroButton';
+		'SpellbookMicroButton';
+		'TalentMicroButton';
+		'AchievementMicroButton';
+		'QuestLogMicroButton';
+		'SocialsMicroButton';
+		'GuildMicroButton';
+		'CollectionsMicroButton';
+		'PVPMicroButton';
+		'LFGMicroButton';
+		'MainMenuMicroButton';
+		'HelpMicroButton';
+	};
+	local RETAIL_MICRO_BUTTONS = {
+		'CharacterMicroButton';
+		'ProfessionMicroButton';
+		'PlayerSpellsMicroButton';
+		'AchievementMicroButton';
+		'QuestLogMicroButton';
+		'HousingMicroButton';
+		'GuildMicroButton';
+		'LFDMicroButton';
+		'CollectionsMicroButton';
+		'EJMicroButton';
+		'HelpMicroButton';
+		'StoreMicroButton';
+		'MainMenuMicroButton';
+	};
+
+	EnsureMicroMenuLoaded = function()
+		if not MicroMenu and not CPAPI.IsAddOnLoaded('Blizzard_MicroMenu') then
+			UIParentLoadAddOn('Blizzard_MicroMenu')
+		end
+	end;
+
+	CollectMicroButtons = function(self)
+		self.MicroButtons = {};
+
+		if MicroMenu then
+			for _, button in ipairs({MicroMenu:GetChildren()}) do
+				if button.layoutIndex then
+					self.MicroButtons[button] = button.layoutIndex;
+				end
+			end
+			if next(self.MicroButtons) then return end;
+
+			if MicroMenu.GenerateButtonInfos then
+				for i, info in ipairs(MicroMenu:GenerateButtonInfos() or {}) do
+					local button = info and info.button;
+					if button then
+						self.MicroButtons[button] = button.layoutIndex or i;
+					end
+				end
+				if next(self.MicroButtons) then return end;
+			end
+		end
+
+		local fallbackList = CPAPI.IsRetailVersion and RETAIL_MICRO_BUTTONS or WRATH_MICRO_BUTTONS;
+		for i, name in ipairs(fallbackList) do
+			local button = _G[name];
+			if button then
+				self.MicroButtons[button] = i;
+			end
+		end
+
+		if not self.didWarnFallbackMicroMenu then
+			self.didWarnFallbackMicroMenu = true;
+			CPAPI.Log('Toolbar micromenu fallback path active (%s list).', CPAPI.IsRetailVersion and 'Retail' or 'Wrath')
+		end
+	end;
+end
+
+function PopoutFrame:RefreshMicroButtons()
+	CollectMicroButtons(self)
+end
+
+function PopoutFrame:HookMicroMenu()
+	if self.microMenuHooked then return end;
+	if not MicroMenu or not MicroMenu.OverrideMicroMenuPosition then return end;
+	hooksecurefunc(MicroMenu, 'OverrideMicroMenuPosition', GenerateClosure(self.OnOverrideMicroMenuPosition, self))
+	self.microMenuHooked = true;
+end
+
+function PopoutFrame:OnEvent(event, ...)
+	if event == 'ADDON_LOADED' then
+		local addon = ...;
+		if addon ~= 'Blizzard_MicroMenu' then return end;
+	end
+	if event == 'ADDON_LOADED' or event == 'PLAYER_ENTERING_WORLD' then
+		self:HookMicroMenu()
+		self:RefreshMicroButtons()
+		if self.props and self.props.micromenu then
+			self:MoveMicroButtons()
+		end
+	end
+end
+
 function PopoutFrame:OnLoad()
 	Mixin(self.Eye, Eye):OnLoad()
 	Mixin(self.Config, Config):OnLoad()
 	Mixin(self.ExitVehicle, ExitVehicle):OnLoad()
+	self:RegisterEvent('ADDON_LOADED')
+	self:RegisterEvent('PLAYER_ENTERING_WORLD')
+	self:SetScript('OnEvent', self.OnEvent)
+	EnsureMicroMenuLoaded()
 
-	self.MicroButtons = {};
-	for i, name in ipairs(MICRO_BUTTONS) do
-		local button = _G[name];
-		if button then
-			self.MicroButtons[button] = CPAPI.IsRetailVersion and button.layoutIndex or i;
-		end
-	end
+	self:RefreshMicroButtons()
 
 	self:SlideOut()
 	RunNextFrame(function()
@@ -318,6 +427,7 @@ function PopoutFrame:OnLoad()
 	if OverrideMicroMenuPosition then
 		hooksecurefunc('OverrideMicroMenuPosition', GenerateClosure(self.OnOverrideMicroMenuPosition, self))
 	end
+	self:HookMicroMenu()
 	if UpdateMicroButtonsParent then
 		hooksecurefunc('UpdateMicroButtonsParent', GenerateClosure(self.OnUpdateMicroButtonsParent, self))
 	end
@@ -350,6 +460,7 @@ function PopoutFrame:Layout()
 end
 
 function PopoutFrame:MoveMicroButtons()
+	self:RefreshMicroButtons()
 	self.Divider1:SetShown(self.props.micromenu)
 	if not self.props.micromenu then return end;
 	for button, index in pairs(self.MicroButtons) do
@@ -407,6 +518,7 @@ end
 function PopoutFrame:OnOverrideMicroMenuPosition(...)
 	if not self.props.micromenu then return end;
 	if not MicroMenu then return end;
+	self:RefreshMicroButtons()
 	for button in pairs(self.MicroButtons) do
 		button:SetParent(MicroMenu)
 	end

--- a/ConsolePort_Bar/View/Toolbar/Toolbar.lua
+++ b/ConsolePort_Bar/View/Toolbar/Toolbar.lua
@@ -297,18 +297,37 @@ end
 ---------------------------------------------------------------
 local PopoutFrame = CreateFromMixins(CPToolbarSixSliceInverterMixin)
 ---------------------------------------------------------------
+function PopoutFrame:RefreshMicroButtons()
+	local microButtons = {};
+
+	-- Titan Reforge: discover micro buttons from the MicroMenu container.
+	if MicroMenu then
+		for _, button in ipairs({MicroMenu:GetChildren()}) do
+			if button.layoutIndex then
+				microButtons[button] = button.layoutIndex;
+			end
+		end
+	end
+
+	-- Retail: fall back to the global list when available.
+	if not next(microButtons) and MICRO_BUTTONS then
+		for i, name in ipairs(MICRO_BUTTONS) do
+			local button = _G[name];
+			if button then
+				microButtons[button] = button.layoutIndex or i;
+			end
+		end
+	end
+
+	self.MicroButtons = microButtons;
+end
+
 function PopoutFrame:OnLoad()
 	Mixin(self.Eye, Eye):OnLoad()
 	Mixin(self.Config, Config):OnLoad()
 	Mixin(self.ExitVehicle, ExitVehicle):OnLoad()
 
-	self.MicroButtons = {};
-	for i, name in ipairs(MICRO_BUTTONS) do
-		local button = _G[name];
-		if button then
-			self.MicroButtons[button] = CPAPI.IsRetailVersion and button.layoutIndex or i;
-		end
-	end
+	self:RefreshMicroButtons()
 
 	self:SlideOut()
 	RunNextFrame(function()
@@ -352,6 +371,7 @@ end
 function PopoutFrame:MoveMicroButtons()
 	self.Divider1:SetShown(self.props.micromenu)
 	if not self.props.micromenu then return end;
+	self:RefreshMicroButtons()
 	for button, index in pairs(self.MicroButtons) do
 		button:SetParent(self)
 		button:ClearAllPoints()

--- a/ConsolePort_Config/ConsolePort_Config.toc
+++ b/ConsolePort_Config/ConsolePort_Config.toc
@@ -1,4 +1,4 @@
-## Interface: 120001, 120000, 50503, 38000, 20505, 11508
+## Interface: 120001, 120000, 50503, 38010, 20505, 11508
 ## IconTexture: Interface\AddOns\ConsolePort\Assets\Textures\Logo\CP_Thumb
 ## Title: Console Port |cff69ccf0Config|r
 ## Notes: Configuration module

--- a/ConsolePort_Cursor/ConsolePort_Cursor.toc
+++ b/ConsolePort_Cursor/ConsolePort_Cursor.toc
@@ -1,4 +1,4 @@
-## Interface: 120001, 120000, 50503, 38000, 20505, 11508
+## Interface: 120001, 120000, 50503, 38010, 20505, 11508
 ## IconTexture: Interface\AddOns\ConsolePort\Assets\Textures\Logo\CP_Thumb
 ## Title: Console Port |cff69ccf0Cursor|r
 ## Notes: Interface cursor module

--- a/ConsolePort_Keyboard/ConsolePort_Keyboard.toc
+++ b/ConsolePort_Keyboard/ConsolePort_Keyboard.toc
@@ -1,4 +1,4 @@
-## Interface: 120001, 120000, 50503, 38000, 20505, 11508
+## Interface: 120001, 120000, 50503, 38010, 20505, 11508
 ## IconTexture: Interface\AddOns\ConsolePort\Assets\Textures\Logo\CP_Thumb
 ## Title: Console Port |cff69ccf0Keyboard|r
 ## Notes: Virtual keyboard module

--- a/ConsolePort_Menu/ConsolePort_Menu.toc
+++ b/ConsolePort_Menu/ConsolePort_Menu.toc
@@ -1,4 +1,4 @@
-## Interface: 120001, 120000, 50503, 38000, 20505, 11508
+## Interface: 120001, 120000, 50503, 38010, 20505, 11508
 ## IconTexture: Interface\AddOns\ConsolePort\Assets\Textures\Logo\CP_Thumb
 ## Title: Console Port |cff69ccf0Menu|r
 ## Notes: Game menu module

--- a/ConsolePort_Rings/ConsolePort_Rings.toc
+++ b/ConsolePort_Rings/ConsolePort_Rings.toc
@@ -1,4 +1,4 @@
-## Interface: 120001, 120000, 50503, 38000, 20505, 11508
+## Interface: 120001, 120000, 50503, 38010, 20505, 11508
 ## IconTexture: Interface\AddOns\ConsolePort\Assets\Textures\Logo\CP_Thumb
 ## Title: Console Port |cff69ccf0Rings|r
 ## Notes: Rings module

--- a/ConsolePort_World/ConsolePort_World.toc
+++ b/ConsolePort_World/ConsolePort_World.toc
@@ -1,4 +1,4 @@
-## Interface: 120001, 120000, 50503, 38000, 20505, 11508
+## Interface: 120001, 120000, 50503, 38010, 20505, 11508
 ## IconTexture: Interface\AddOns\ConsolePort\Assets\Textures\Logo\CP_Thumb
 ## Title: Console Port |cff69ccf0World|r
 ## Notes: World augmentation: quick menu, custom loot frame, ability prompts


### PR DESCRIPTION
This PR adds compatibility for the recently updated WoW Titan Reforged client. 

After digging into the [`wow-ui-source`](https://github.com/Gethe/wow-ui-source/commit/afd96906dc4a82480117614afddf738f96957ace#diff-adf112f5d446329bba454c559f87eb8a3c92da7ce9239d17bc7db381d7e398ad) following the recent patch, it became clear that Titan Reforged shares a significant amount of code with the Retail version. Therefore, I implemented a solution that maximizes the reuse of our existing Retail code. The newly added logic leverages these similarities, resulting in a unified codebase that operates perfectly on both Retail and Titan Reforged (`IsWrathVersion`) clients.

I've tested on both titan reforged client and retail client. Let me if you have any questions