### PR TITLE
Added a local Micro Button list for iteration

### DIFF
--- a/ConsolePort_Bar/View/Toolbar/Toolbar.lua
+++ b/ConsolePort_Bar/View/Toolbar/Toolbar.lua
@@ -302,13 +302,29 @@ function PopoutFrame:OnLoad()
 	Mixin(self.Config, Config):OnLoad()
 	Mixin(self.ExitVehicle, ExitVehicle):OnLoad()
 
-	self.MicroButtons = {};
-	for i, name in ipairs(MICRO_BUTTONS) do
-		local button = _G[name];
-		if button then
-			self.MicroButtons[button] = CPAPI.IsRetailVersion and button.layoutIndex or i;
-		end
-	end
+  local MICRO_BUTTONS_CONSOLEPORT = {
+      "CharacterMicroButton",
+      "ProfessionMicroButton",
+      "PlayerSpellsMicroButton",
+      "AchievementMicroButton",
+      "QuestLogMicroButton",
+      "HousingMicroButton",
+      "GuildMicroButton",
+      "LFDMicroButton",
+      "EJMicroButton",
+      "CollectionsMicroButton",
+      "MainMenuMicroButton",
+      "HelpMicroButton",
+      "StoreMicroButton",
+  }
+  
+  self.MicroButtons = {};
+  for i, name in ipairs(MICRO_BUTTONS or MICRO_BUTTONS_CONSOLEPORT) do
+      local button = _G[name];
+      if button then
+          self.MicroButtons[button] = CPAPI.IsRetailVersion and button.layoutIndex or i;
+      end
+  end
 
 	self:SlideOut()
 	RunNextFrame(function()


### PR DESCRIPTION
Fixes issue #179 

Since WoW removed global var MICRO_BUTTONS, this fix created a local var MICRO_BUTTONS_CONSOLEPORT for the function to iterate through. 