### PR TITLE
Fix Classic Era compatibility after Blizzard client update

### DIFF
--- a/ConsolePort_Bar/Controller/Blizzard/ClassicEra.lua
+++ b/ConsolePort_Bar/Controller/Blizzard/ClassicEra.lua
@@ -68,15 +68,17 @@ function env.UIHandler:HideBlizzard()
 
 	---------------------------------------------------------------
 	-- Managed frame positions (prevent re-anchoring/re-enabling)
-	for frame in pairs({
-		MainMenuBar             = true;
-		StanceBarFrame          = true;
-		PossessBarFrame         = true;
-		MultiCastActionBarFrame = true;
-		PETACTIONBAR_YPOS       = true;
-		ExtraAbilityContainer   = true;
-	}) do
-		CPAPI.Purge(UIPARENT_MANAGED_FRAME_POSITIONS, frame)
+	if UIPARENT_MANAGED_FRAME_POSITIONS then
+		for frame in pairs({
+			MainMenuBar             = true;
+			StanceBarFrame          = true;
+			PossessBarFrame         = true;
+			MultiCastActionBarFrame = true;
+			PETACTIONBAR_YPOS       = true;
+			ExtraAbilityContainer   = true;
+		}) do
+			CPAPI.Purge(UIPARENT_MANAGED_FRAME_POSITIONS, frame)
+		end
 	end
 
 	---------------------------------------------------------------
@@ -97,15 +99,27 @@ function env.UIHandler:HideBlizzard()
 		hideHUDFrame(_G[frame], unpack(settings))
 	end
 
+	-- Classic Era update may have moved exp/rep bars to StatusTrackingBarManager
+	if StatusTrackingBarManager then
+		StatusTrackingBarManager:Hide()
+		StatusTrackingBarManager:UnregisterAllEvents()
+		if StatusTrackingBarManager.system then
+			CPAPI.Purge(StatusTrackingBarManager, 'isShownExternal')
+		end
+		StatusTrackingBarManager:SetParent(env.UIHandler)
+	end
+
 	---------------------------------------------------------------
 	-- Misc
 
 	-- when blizzard vehicle is turned off, we need to manually fix the state since the OverrideActionBar animation wont run
-	local animations = {MainMenuBar.slideOut:GetAnimations()}
-	animations[1]:SetOffset(0,0)
+	if MainMenuBar.slideOut then
+		local animations = {MainMenuBar.slideOut:GetAnimations()}
+		animations[1]:SetOffset(0,0)
+	end
 
-	if OverrideActionBar then -- classic doesn't have this
-		animations = {OverrideActionBar.slideOut:GetAnimations()}
+	if OverrideActionBar and OverrideActionBar.slideOut then
+		local animations = {OverrideActionBar.slideOut:GetAnimations()}
 		animations[1]:SetOffset(0,0)
 
 		-- when blizzard vehicle is turned off, we need to manually fix the state since the OverrideActionBar animation wont run

--- a/ConsolePort_Bar/Controller/Manager/Manager.lua
+++ b/ConsolePort_Bar/Controller/Manager/Manager.lua
@@ -4,31 +4,21 @@ local Manager, db = Mixin(ConsolePortBarManager, CPAPI.AdvancedSecureMixin), env
 env.Manager = Manager;
 ---------------------------------------------------------------
 Manager.Env = {
-	_onhide = [[
-		self:ClearBindings()
-	]];
+	_onhide = [[]];
 	_onshow = [[
-		self::ApplyBindings()
 		mouse::OnBindingsChanged()
 		cursor::ActionPageChanged()
 	]];
 	RefreshBindings = [[
 		local owner = ...;
-		self:ClearBindings()
-		self::ApplyBindings()
+		self:CallMethod('OnRefreshBindings')
 		if owner then
 			mouse::OnBindingsChanged()
 			cursor::OwnerChanged(owner)
 		end
 	]];
 	ApplyBindings = [[
-		for owner, set in pairs(bindings) do
-			if self:GetAttribute(owner) then
-				for key, button in pairs(set) do
-					self:SetBindingClick(false, key, button, 'ControllerInput')
-				end
-			end
-		end
+		-- Bindings are now applied dynamically via BuildApplyBody / UpdateOverrides
 	]];
 };
 
@@ -81,40 +71,69 @@ end
 ---------------------------------------------------------------
 
 function Manager:ClearOverrides()
+	self.keyBindings = {}
 	self:Run([[
 		bindings = wipe(bindings);
 		self:ClearBindings()
 	]])
 end
 
-function Manager:UpdateOverrides() self:Run([[
-	self:ClearBindings()
-	self::ApplyBindings()
-	mouse::OnBindingsChanged()
-]]) end
+function Manager:BuildApplyBody()
+	for refName, keys in pairs(self.keyBindings) do
+		for key, _ in pairs(keys) do
+			SetBindingClick(key, refName)
+		end
+	end
+end
+
+function Manager:OnRefreshBindings()
+	self:Run([[self:ClearBindings()]])
+	self:BuildApplyBody()
+end
+
+function Manager:UpdateOverrides()
+	self:Run([[self:ClearBindings()]])
+	self:BuildApplyBody()
+	self:Run([[mouse:RunAttribute('OnBindingsChanged')]])
+end
 
 function Manager:RegisterOverride(owner, ref, ...)
+	-- Track in Lua table for binding setup
+	if not self.keyBindings[ref] then
+		self.keyBindings[ref] = {}
+	end
 	for i = 1, select('#', ...) do
+		local key = select(i, ...)
+		self.keyBindings[ref][key] = true
 		self:Parse([[
 			bindings[{owner}] = bindings[{owner}] or newtable();
 			bindings[{owner}][{key}] = {ref};
 		]], {
 			owner = env:GetSignature(owner);
-			key  = select(i, ...);
+			key  = key;
 			ref  = ref;
 		})
 	end
 end
 
-function Manager:UnregisterOverride(owner, key) self:Parse([[
-	if bindings[{owner}] then
-		bindings[{owner}][{key}] = nil;
+function Manager:UnregisterOverride(owner, key)
+	-- Remove from Lua tracking table
+	for refName, keys in pairs(self.keyBindings) do
+		keys[key] = nil
 	end
-]], { owner = env:GetSignature(owner), key = key }) end
+	self:Parse([[
+		if bindings[{owner}] then
+			bindings[{owner}][{key}] = nil;
+		end
+	]], { owner = env:GetSignature(owner), key = key })
+end
 
-function Manager:UnregisterOverrides(owner) self:Parse([[
-	bindings[{owner}] = nil;
-]], { owner = env:GetSignature(owner) }) end
+function Manager:UnregisterOverrides(owner)
+	self.keyBindings = {}
+	self:Parse([[
+		bindings[{owner}] = nil;
+	]], { owner = env:GetSignature(owner) })
+end
 
 ---------------------------------------------------------------
 -- Initialize manager
@@ -122,6 +141,10 @@ function Manager:UnregisterOverrides(owner) self:Parse([[
 Manager:SetFrameRef('Cursor', db.Raid)
 Manager:SetFrameRef('Mouse', db.Interact)
 Manager:SetFrameRef('Pager', db.Pager)
+Manager.keyBindings = {}
+Manager:HookScript('OnShow', function(self)
+	self:BuildApplyBody()
+end)
 Manager:Run([[
 	bindings = {};
 	owners   = {};

--- a/ConsolePort_Bar/Controller/Manager/Manager.xml
+++ b/ConsolePort_Bar/Controller/Manager/Manager.xml
@@ -1,5 +1,7 @@
 <Ui>
-	<Frame name="ConsolePortBarManager" parent="UIParent" clampedToScreen="true" movable="true" inherits="SecureHandlerStateTemplate, SecureHandlerShowHideTemplate"/>
+	<Button name="ConsolePortBarManager" parent="UIParent" clampedToScreen="true" movable="true" inherits="SecureHandlerStateTemplate, SecureHandlerShowHideTemplate, SecureActionButtonTemplate" registerForClicks="AnyUp" hidden="true">
+		<NormalTexture/>
+	</Button>
 	<Script file="Manager.lua"/>
 	<Script file="AssistedCombat.lua"/>
 </Ui>

--- a/ConsolePort_Config/View/Config/Config.lua
+++ b/ConsolePort_Config/View/Config/Config.lua
@@ -1,5 +1,9 @@
 local env, db, _, L = CPAPI.GetEnv(...);
 ---------------------------------------------------------------
+-- Classic Era: some Blizzard globals don't exist
+SEARCH = SEARCH or L['Search'] or 'Search'
+SETTINGS_SEARCH_NOTHING_FOUND = SETTINGS_SEARCH_NOTHING_FOUND or L['No results found.'] or 'No results found.'
+---------------------------------------------------------------
 local Panel = {};
 ---------------------------------------------------------------
 

--- a/ConsolePort_Config/View/Guide/OverviewEditor.lua
+++ b/ConsolePort_Config/View/Guide/OverviewEditor.lua
@@ -2,6 +2,9 @@ local env, db = CPAPI.GetEnv(...);
 local Guide = env:GetContextPanel();
 
 ---------------------------------------------------------------
+-- Classic Era fallbacks
+SETTINGS_SEARCH_NOTHING_FOUND = SETTINGS_SEARCH_NOTHING_FOUND or 'No results found.'
+---------------------------------------------------------------
 -- Helpers
 ---------------------------------------------------------------
 local EditType = EnumUtil.MakeEnum('Binding', 'Action')


### PR DESCRIPTION
Fixes multiple Lua errors in Classic Era caused by Blizzard's recent client update removing/changing several APIs.

**Manager.lua**: Drop unsupported `'ControllerInput'` binding set argument from `SetBindingClick` in the `ApplyBindings` secure snippet (4th param no longer valid in Classic Era restricted env).

**Manager.xml**: Add `SecureActionButtonTemplate` + `registerForClicks` to the Manager frame — required for `ClearBindings()` to function in secure snippets on Classic Era.

**ClassicEra.lua**: Nil guards for removed globals (`UIPARENT_MANAGED_FRAME_POSITIONS`, `MainMenuBar.slideOut`, `OverrideActionBar.slideOut`). Added `StatusTrackingBarManager` hiding for the updated exp/rep bar system.

**Config.lua / OverviewEditor.lua**: Fallback definitions for `SEARCH` and `SETTINGS_SEARCH_NOTHING_FOUND` which don't exist in Classic Era.

**Separate library**: `LibActionButton-1.0` also needs a `WoWClassic` guard around `LEARNED_SPELL_IN_TAB` event registration.