### PR TITLE
Performance fixes

### DIFF
--- a/ConsolePort/Model/Data/Data.lua
+++ b/ConsolePort/Model/Data/Data.lua
@@ -74,19 +74,6 @@ db:RegisterCallback('OnToggleCharacterSettings', DataAPI.OnToggleCharacterSettin
 ---------------------------------------------------------------
 local ID, DATA, TYPE, CALL, INIT, DEF = 0x0, 0x1, 0x2, 0x3, 0x4, 0x5;
 
--- Deep copy sharing metatables, which copy() duplicates per node.
--- Instances only; subtypes need private metatables for their methods.
-local function copyShared(src)
-	if type(src) ~= 'table' then
-		return src;
-	end
-	local t = {};
-	for key, value in next, src, nil do
-		t[key] = copyShared(value);
-	end
-	return setmetatable(t, getmetatable(src));
-end
-
 local Field = setmetatable({[TYPE] = 'Field'}, {
 	__index = {};
 	__newindex = function(self, key, value)
@@ -100,7 +87,7 @@ local Field = setmetatable({[TYPE] = 'Field'}, {
 		if newType then
 			return rawset(copy(self), TYPE, newType);
 		end
-		return copyShared(self);
+		return copy(self);
 	end;
 });
 
@@ -309,7 +296,6 @@ local Table = Field('Table');
 
 function Table:Get()
 	local result = {};
-	-- Raw read; Field.Get would deep-copy values the loop below discards.
 	local data = rawget(self, DATA);
 	for child, field in pairs(data) do
 		result[child] = field[DATA]:Get();

--- a/ConsolePort/Model/Data/Data.lua
+++ b/ConsolePort/Model/Data/Data.lua
@@ -74,6 +74,19 @@ db:RegisterCallback('OnToggleCharacterSettings', DataAPI.OnToggleCharacterSettin
 ---------------------------------------------------------------
 local ID, DATA, TYPE, CALL, INIT, DEF = 0x0, 0x1, 0x2, 0x3, 0x4, 0x5;
 
+-- Deep copy sharing metatables, which copy() duplicates per node.
+-- Instances only; subtypes need private metatables for their methods.
+local function copyShared(src)
+	if type(src) ~= 'table' then
+		return src;
+	end
+	local t = {};
+	for key, value in next, src, nil do
+		t[key] = copyShared(value);
+	end
+	return setmetatable(t, getmetatable(src));
+end
+
 local Field = setmetatable({[TYPE] = 'Field'}, {
 	__index = {};
 	__newindex = function(self, key, value)
@@ -87,7 +100,7 @@ local Field = setmetatable({[TYPE] = 'Field'}, {
 		if newType then
 			return rawset(copy(self), TYPE, newType);
 		end
-		return setmetatable(copy(self), getmetatable(self));
+		return copyShared(self);
 	end;
 });
 
@@ -296,7 +309,8 @@ local Table = Field('Table');
 
 function Table:Get()
 	local result = {};
-	local data = Field.Get(self);
+	-- Raw read; Field.Get would deep-copy values the loop below discards.
+	local data = rawget(self, DATA);
 	for child, field in pairs(data) do
 		result[child] = field[DATA]:Get();
 	end

--- a/ConsolePort/Model/Data/Data.lua
+++ b/ConsolePort/Model/Data/Data.lua
@@ -87,7 +87,8 @@ local Field = setmetatable({[TYPE] = 'Field'}, {
 		if newType then
 			return rawset(copy(self), TYPE, newType);
 		end
-		return copy(self);
+		local shareMeta = true;
+		return copy(self, shareMeta);
 	end;
 });
 

--- a/ConsolePort/Model/Game/Actionbar.lua
+++ b/ConsolePort/Model/Game/Actionbar.lua
@@ -153,17 +153,8 @@ do
 	---------------------------------------------------------------
 	-- Get all buttons that look like action buttons
 	---------------------------------------------------------------
-	local buttonCache, barCache
-
-	function ActionBarAPI:InvalidateActionCache()
-		buttonCache, barCache = nil, nil
-	end
-
 	function ActionBarAPI:GetActionButtons(asTable, parent)
-		if not parent and not buttonCache then
-			buttonCache = FindActionButtons(CacheActionButton, {}, UIParent)
-		end
-		local buttons = parent and FindActionButtons(CacheActionButton, {}, parent) or buttonCache
+		local buttons = FindActionButtons(CacheActionButton, {}, parent or UIParent)
 		if asTable then return buttons end
 		return pairs(buttons)
 	end
@@ -172,21 +163,14 @@ do
 	-- Get all container frames that look like action bars
 	---------------------------------------------------------------
 	function ActionBarAPI:GetActionBars(asTable, parent)
-		if not parent and not barCache then
-			barCache = FindActionButtons(CacheActionBar, {}, UIParent)
-		end
-		local bars = parent and FindActionButtons(CacheActionBar, {}, parent) or barCache
+		local bars = FindActionButtons(CacheActionBar, {}, parent or UIParent)
 		if asTable then return bars end
 		return pairs(bars)
 	end
 
 	function ActionBarAPI:SetIgnoreFrameForActionLookup(frame, enabled)
 		IGNORE_FRAMES[frame] = enabled or nil
-		ActionBarAPI:InvalidateActionCache()
 	end
-
-	db:RegisterCallback('OnNewBindings', ActionBarAPI.InvalidateActionCache, ActionBarAPI)
-	db:RegisterCallback('OnActionPageChanged', ActionBarAPI.InvalidateActionCache, ActionBarAPI)
 
 	---------------------------------------------------------------
 	-- Database proxy

--- a/ConsolePort/Model/Game/Actionbar.lua
+++ b/ConsolePort/Model/Game/Actionbar.lua
@@ -153,8 +153,17 @@ do
 	---------------------------------------------------------------
 	-- Get all buttons that look like action buttons
 	---------------------------------------------------------------
+	local buttonCache, barCache
+
+	function ActionBarAPI:InvalidateActionCache()
+		buttonCache, barCache = nil, nil
+	end
+
 	function ActionBarAPI:GetActionButtons(asTable, parent)
-		local buttons = FindActionButtons(CacheActionButton, {}, parent or UIParent)
+		if not parent and not buttonCache then
+			buttonCache = FindActionButtons(CacheActionButton, {}, UIParent)
+		end
+		local buttons = parent and FindActionButtons(CacheActionButton, {}, parent) or buttonCache
 		if asTable then return buttons end
 		return pairs(buttons)
 	end
@@ -163,14 +172,21 @@ do
 	-- Get all container frames that look like action bars
 	---------------------------------------------------------------
 	function ActionBarAPI:GetActionBars(asTable, parent)
-		local bars = FindActionButtons(CacheActionBar, {}, parent or UIParent)
+		if not parent and not barCache then
+			barCache = FindActionButtons(CacheActionBar, {}, UIParent)
+		end
+		local bars = parent and FindActionButtons(CacheActionBar, {}, parent) or barCache
 		if asTable then return bars end
 		return pairs(bars)
 	end
 
 	function ActionBarAPI:SetIgnoreFrameForActionLookup(frame, enabled)
-		IGNORE_FRAMES[frame] = enabled
+		IGNORE_FRAMES[frame] = enabled or nil
+		ActionBarAPI:InvalidateActionCache()
 	end
+
+	db:RegisterCallback('OnNewBindings', ActionBarAPI.InvalidateActionCache, ActionBarAPI)
+	db:RegisterCallback('OnActionPageChanged', ActionBarAPI.InvalidateActionCache, ActionBarAPI)
 
 	---------------------------------------------------------------
 	-- Database proxy

--- a/ConsolePort/Model/Game/Loadout.lua
+++ b/ConsolePort/Model/Game/Loadout.lua
@@ -130,10 +130,11 @@ function LoadoutInfo:RefreshDictionary()
 		end
 
 		-- XML-registered bindings
+		local headerPrefix = self.HeaderPrefix
 		for i=1, numBindings do
 			local id, header = GetBinding(i)
 
-			if not id:match('^HEADER') then
+			if id:find('HEADER', 1, true) ~= 1 then
 				-- link binding IDs to their headers
 				headers[id] = header;
 
@@ -142,7 +143,7 @@ function LoadoutInfo:RefreshDictionary()
 				-- GetBindingName() can't be verified since it returns the
 				-- original string if it doesn't find a match.
 				local global = self:GetBindingName(id)
-				local name   = tostring(global or _G[self.HeaderPrefix:format(id)] or id);
+				local name   = tostring(global or _G[headerPrefix:format(id)] or id);
 				local action = self:GetActionButtonID(id)
 
 				if action then

--- a/ConsolePort/Model/Gamepad/Gamepad.lua
+++ b/ConsolePort/Model/Gamepad/Gamepad.lua
@@ -394,46 +394,38 @@ end
 function GamepadAPI:GetActiveModifiers()
 	local mods = db.table.copy(self.Index.Modifier.Prefix)
 	local driver = {'[nomod] '};
+	local spairs = db.table.spairs; -- need to scan in-order
 
-	-- Never more than three modifiers, so emit the combinations directly.
-	local keys = {};
-	for mod in pairs(mods) do keys[#keys + 1] = mod end
-	table.sort(keys)
-
-	local function addSingle(K)
-		driver[#driver + 1] = ('[mod:%s] %s'):format(K, K)
-	end
-
-	local function addDouble(K1, K2)
-		local modifier = K1..K2
-		mods[modifier] = ('%s-%s'):format(mods[K1], mods[K2])
-		driver[#driver + 1] = ('[mod:%s] %s'):format(modifier, modifier)
-	end
-
-	local function addTriple(K1, K2, K3)
-		local modifier = K1..K2..K3
-		mods[modifier] = ('%s-%s-%s'):format(mods[K1], mods[K2], mods[K3])
-		driver[#driver + 1] = ('[mod:%s] %s'):format(modifier, modifier)
-	end
-
-	-- Most-specific first; the state driver takes the first match.
-	local K1, K2, K3 = keys[1], keys[2], keys[3]
-	if K1 then
-		if K2 then
-			if K3 then
-				addTriple(K1, K2, K3)
-				addDouble(K2, K3)
-				addDouble(K1, K3)
-			end
-			addDouble(K1, K2)
-			addSingle(K2)
-			if K3 then
-				addSingle(K3)
+	local function assertUniqueAndInOrder(...)
+		local uniques = {}
+		for i=1, select('#', ...) do
+			local v1 = select(i, ...)
+			if uniques[v1] then return end
+			uniques[v1] = true
+			for v2 in pairs(uniques) do
+				if v2 > v1 then return end
 			end
 		end
-		addSingle(K1)
+		return true
 	end
 
+	for M1, K1 in spairs(mods) do
+		for M2, K2 in spairs(mods) do
+			for M3, K3 in spairs(mods) do
+				if (assertUniqueAndInOrder(M1, M2, M3)) then
+					local modifier = M1..M2..M3;
+					mods[modifier] = ('%s-%s-%s'):format(K1, K2, K3)
+					tinsert(driver, ('[mod:%s] %s'):format(modifier, modifier))
+				end
+			end
+			if (assertUniqueAndInOrder(M1, M2)) then
+				local modifier = M1..M2;
+				mods[modifier] = ('%s-%s'):format(K1, K2)
+				tinsert(driver, ('[mod:%s] %s'):format(modifier, modifier))
+			end
+		end
+		tinsert(driver, ('[mod:%s] %s'):format(M1, M1))
+	end
 	mods[NM] = true
 	return mods, table.concat(driver, '; ');
 end

--- a/ConsolePort/Model/Gamepad/Gamepad.lua
+++ b/ConsolePort/Model/Gamepad/Gamepad.lua
@@ -394,38 +394,46 @@ end
 function GamepadAPI:GetActiveModifiers()
 	local mods = db.table.copy(self.Index.Modifier.Prefix)
 	local driver = {'[nomod] '};
-	local spairs = db.table.spairs; -- need to scan in-order
 
-	local function assertUniqueAndInOrder(...)
-		local uniques = {}
-		for i=1, select('#', ...) do
-			local v1 = select(i, ...)
-			if uniques[v1] then return end
-			uniques[v1] = true
-			for v2 in pairs(uniques) do
-				if v2 > v1 then return end
-			end
-		end
-		return true
+	-- Never more than three modifiers, so emit the combinations directly.
+	local keys = {};
+	for mod in pairs(mods) do keys[#keys + 1] = mod end
+	table.sort(keys)
+
+	local function addSingle(K)
+		driver[#driver + 1] = ('[mod:%s] %s'):format(K, K)
 	end
 
-	for M1, K1 in spairs(mods) do
-		for M2, K2 in spairs(mods) do
-			for M3, K3 in spairs(mods) do
-				if (assertUniqueAndInOrder(M1, M2, M3)) then
-					local modifier = M1..M2..M3;
-					mods[modifier] = ('%s-%s-%s'):format(K1, K2, K3)
-					tinsert(driver, ('[mod:%s] %s'):format(modifier, modifier))
-				end
+	local function addDouble(K1, K2)
+		local modifier = K1..K2
+		mods[modifier] = ('%s-%s'):format(mods[K1], mods[K2])
+		driver[#driver + 1] = ('[mod:%s] %s'):format(modifier, modifier)
+	end
+
+	local function addTriple(K1, K2, K3)
+		local modifier = K1..K2..K3
+		mods[modifier] = ('%s-%s-%s'):format(mods[K1], mods[K2], mods[K3])
+		driver[#driver + 1] = ('[mod:%s] %s'):format(modifier, modifier)
+	end
+
+	-- Most-specific first; the state driver takes the first match.
+	local K1, K2, K3 = keys[1], keys[2], keys[3]
+	if K1 then
+		if K2 then
+			if K3 then
+				addTriple(K1, K2, K3)
+				addDouble(K2, K3)
+				addDouble(K1, K3)
 			end
-			if (assertUniqueAndInOrder(M1, M2)) then
-				local modifier = M1..M2;
-				mods[modifier] = ('%s-%s'):format(K1, K2)
-				tinsert(driver, ('[mod:%s] %s'):format(modifier, modifier))
+			addDouble(K1, K2)
+			addSingle(K2)
+			if K3 then
+				addSingle(K3)
 			end
 		end
-		tinsert(driver, ('[mod:%s] %s'):format(M1, M1))
+		addSingle(K1)
 	end
+
 	mods[NM] = true
 	return mods, table.concat(driver, '; ');
 end
@@ -480,13 +488,14 @@ function GamepadAPI:GetBindings(getInactive)
 
 	local bindings = {};
 	for btn in pairs(btns) do
+		local set = {}
 		for mod in pairs(mods) do
 			local binding = CPAPI.GetBindingAction(mod..btn)
-			if getInactive or binding:len() > 0 then
-				bindings[btn] = bindings[btn] or {};
-				bindings[btn][mod] = binding;
+			if getInactive or binding ~= '' then
+				set[mod] = binding
 			end
 		end
+		if next(set) then bindings[btn] = set end
 	end
 	return bindings;
 end

--- a/ConsolePort/Model/Gamepad/Gamepad.lua
+++ b/ConsolePort/Model/Gamepad/Gamepad.lua
@@ -394,38 +394,25 @@ end
 function GamepadAPI:GetActiveModifiers()
 	local mods = db.table.copy(self.Index.Modifier.Prefix)
 	local driver = {'[nomod] '};
-	local spairs = db.table.spairs; -- need to scan in-order
 
-	local function assertUniqueAndInOrder(...)
-		local uniques = {}
-		for i=1, select('#', ...) do
-			local v1 = select(i, ...)
-			if uniques[v1] then return end
-			uniques[v1] = true
-			for v2 in pairs(uniques) do
-				if v2 > v1 then return end
-			end
-		end
-		return true
-	end
+	local keys = {};
+	for mod in pairs(mods) do keys[#keys + 1] = mod end
+	table.sort(keys)
 
-	for M1, K1 in spairs(mods) do
-		for M2, K2 in spairs(mods) do
-			for M3, K3 in spairs(mods) do
-				if (assertUniqueAndInOrder(M1, M2, M3)) then
-					local modifier = M1..M2..M3;
-					mods[modifier] = ('%s-%s-%s'):format(K1, K2, K3)
-					tinsert(driver, ('[mod:%s] %s'):format(modifier, modifier))
-				end
-			end
-			if (assertUniqueAndInOrder(M1, M2)) then
-				local modifier = M1..M2;
-				mods[modifier] = ('%s-%s'):format(K1, K2)
-				tinsert(driver, ('[mod:%s] %s'):format(modifier, modifier))
-			end
+	-- Emit longer combinations before shorter ones, so the driver takes the most specific match.
+	local function combine(combo, chord, index)
+		for i = index + 1, #keys do
+			combine(combo..keys[i], chord and chord..'-'..mods[keys[i]] or mods[keys[i]], i)
 		end
-		tinsert(driver, ('[mod:%s] %s'):format(M1, M1))
+		if ( combo ~= '' ) then
+			if not mods[combo] then
+				mods[combo] = chord;
+			end
+			driver[#driver + 1] = ('[mod:%s] %s'):format(combo, combo)
+		end
 	end
+	combine('', nil, 0)
+
 	mods[NM] = true
 	return mods, table.concat(driver, '; ');
 end

--- a/ConsolePort/View/Hotkey.lua
+++ b/ConsolePort/View/Hotkey.lua
@@ -9,8 +9,9 @@ local HotkeyMixin, HotkeyHandler = {}, CPAPI.CreateEventHandler({'Frame', '$pare
 	'UPDATE_BINDINGS';
 })
 db:Register('Hotkeys', HotkeyHandler)
+HotkeyHandler.Cache    = setmetatable({}, {__mode = 'v'})
 HotkeyHandler.Textures = CreateTexturePool(HotkeyHandler, 'ARTWORK')
-HotkeyHandler.Widgets = CreateFramePool('Frame', HotkeyHandler, nil, function(pool, self)
+HotkeyHandler.Widgets  = CreateFramePool('Frame', HotkeyHandler, nil, function(pool, self)
 	self:Hide()
 	self:ClearAllPoints()
 	if self.Release then
@@ -22,7 +23,18 @@ end)
 ---------------------------------------------------------------
 -- Events
 ---------------------------------------------------------------
+function HotkeyHandler:GetActionButtons()
+	local buttons = self.Cache.Buttons;
+	if not buttons then
+		buttons = db.Actionbar:GetActionButtons(true)
+		self.Cache.Buttons = buttons;
+	end
+	return pairs(buttons)
+end
+
 function HotkeyHandler:ADDON_LOADED(...)
+	-- clear cache on addon load, since action buttons may have been created
+	self.Cache.Buttons = nil;
 	-- need to run this on every addon loading
 	self:OnInterfaceUpdated()
 end
@@ -36,16 +48,15 @@ function HotkeyHandler:OnInterfaceUpdated()
 	self:QueueHotkeyUpdate()
 end
 
-function HotkeyHandler:RefreshHotkeys()
+HotkeyHandler.QueueHotkeyUpdate = CPAPI.Debounce(function(self)
 	local device = db.Gamepad:GetActiveDevice()
 	if device then
 		self:UpdateHotkeys(device)
 	end
-end
-
-HotkeyHandler.QueueHotkeyUpdate = CPAPI.Debounce(HotkeyHandler.RefreshHotkeys, HotkeyHandler)
+end, HotkeyHandler)
 
 db:RegisterCallback('Gamepad/Active', HotkeyHandler.OnInterfaceUpdated, HotkeyHandler)
+db:RegisterCallback('Settings/disableHotkeyRendering', HotkeyHandler.OnInterfaceUpdated, HotkeyHandler)
 
 ---------------------------------------------------------------
 -- API
@@ -194,7 +205,7 @@ function HotkeyHandler:UpdateHotkeys(device)
 	end
 
 	-- draw on action buttons
-	for owner, action in db.Actionbar:GetActionButtons() do
+	for owner, action in self:GetActionButtons() do
 		local data = bindingToActionID[db('Actionbar/Action/'..action)]
 		if data then
 			self:GetWidget():SetData(data, owner)

--- a/ConsolePort/View/Hotkey.lua
+++ b/ConsolePort/View/Hotkey.lua
@@ -7,7 +7,6 @@
 local _, db = ...;
 local HotkeyMixin, HotkeyHandler = {}, CPAPI.CreateEventHandler({'Frame', '$parentHotkeyHandler', ConsolePort}, {
 	'UPDATE_BINDINGS';
-	'MODIFIER_STATE_CHANGED';
 })
 db:Register('Hotkeys', HotkeyHandler)
 HotkeyHandler.Textures = CreateTexturePool(HotkeyHandler, 'ARTWORK')
@@ -32,31 +31,21 @@ function HotkeyHandler:UPDATE_BINDINGS(...)
 	self:OnInterfaceUpdated()
 end
 
-function HotkeyHandler:MODIFIER_STATE_CHANGED(...)
-	for widget in self.Widgets:EnumerateActive() do
-		-- TODO: dispatch modifier
-	end
-end
-
 function HotkeyHandler:OnInterfaceUpdated()
-	-- hotkey rendering is expensive, make sure it doesn't run unnecessarily
-	if not self.timeLock then
-		self.timeLock = true
-		C_Timer.After(0.5, function()
-			self:OnActiveDeviceChanged()
-			self.timeLock = nil
-		end)
-	end
+	-- hotkey rendering is expensive, coalesce all triggers into one update
+	self:QueueHotkeyUpdate()
 end
 
-function HotkeyHandler:OnActiveDeviceChanged()
+function HotkeyHandler:RefreshHotkeys()
 	local device = db.Gamepad:GetActiveDevice()
 	if device then
 		self:UpdateHotkeys(device)
 	end
 end
 
-db:RegisterCallback('Gamepad/Active', HotkeyHandler.OnActiveDeviceChanged, HotkeyHandler)
+HotkeyHandler.QueueHotkeyUpdate = CPAPI.Debounce(HotkeyHandler.RefreshHotkeys, HotkeyHandler)
+
+db:RegisterCallback('Gamepad/Active', HotkeyHandler.OnInterfaceUpdated, HotkeyHandler)
 
 ---------------------------------------------------------------
 -- API
@@ -175,7 +164,7 @@ function HotkeyHandler:Enable()
 	for _, event in ipairs(self.Events) do
 		self:RegisterEvent(event)
 	end
-	self:OnActiveDeviceChanged()
+	self:OnInterfaceUpdated()
 end
 
 ---------------------------------------------------------------

--- a/ConsolePort_Bar/Model/Utils.lua
+++ b/ConsolePort_Bar/Model/Utils.lua
@@ -135,6 +135,7 @@ do -- Widget factory
 			end
 		end
 		ActiveWidgets[Widgets[signature]] = signature;
+		self:InvalidateConfigCache()
 		return Widgets[signature];
 	end
 
@@ -157,6 +158,7 @@ do -- Widget factory
 
 	function env:Release(widget, release)
 		ActiveWidgets[widget] = nil;
+		self:InvalidateConfigCache()
 		(release or HideAndClearAnchors)(widget);
 		if widget.OnRelease then
 			widget:OnRelease();
@@ -164,6 +166,7 @@ do -- Widget factory
 	end
 
 	function env:ReleaseAll()
+		self:InvalidateConfigCache()
 		repeat
 			for widget in pairs(ActiveWidgets) do
 				self:Release(widget);
@@ -204,6 +207,10 @@ do -- Widget factory
 	end
 
 	function env:GetConfiguration()
+		if self._configCache then
+			return self._configCache;
+		end
+
 		local hierarchy = {};
 
 		local function scaffold(widget, sig)
@@ -227,7 +234,12 @@ do -- Widget factory
 			end
 		end
 
+		self._configCache = hierarchy;
 		return hierarchy;
+	end
+
+	function env:InvalidateConfigCache()
+		self._configCache = nil;
 	end
 
 end -- Widget factory

--- a/ConsolePort_Bar/Model/Utils.lua
+++ b/ConsolePort_Bar/Model/Utils.lua
@@ -135,7 +135,6 @@ do -- Widget factory
 			end
 		end
 		ActiveWidgets[Widgets[signature]] = signature;
-		self:InvalidateConfigCache()
 		return Widgets[signature];
 	end
 
@@ -158,7 +157,6 @@ do -- Widget factory
 
 	function env:Release(widget, release)
 		ActiveWidgets[widget] = nil;
-		self:InvalidateConfigCache();
 		(release or HideAndClearAnchors)(widget);
 		if widget.OnRelease then
 			widget:OnRelease();
@@ -166,7 +164,6 @@ do -- Widget factory
 	end
 
 	function env:ReleaseAll()
-		self:InvalidateConfigCache()
 		repeat
 			for widget in pairs(ActiveWidgets) do
 				self:Release(widget);
@@ -207,10 +204,6 @@ do -- Widget factory
 	end
 
 	function env:GetConfiguration()
-		if self._configCache then
-			return self._configCache;
-		end
-
 		local hierarchy = {};
 
 		local function scaffold(widget, sig)
@@ -234,12 +227,7 @@ do -- Widget factory
 			end
 		end
 
-		self._configCache = hierarchy;
 		return hierarchy;
-	end
-
-	function env:InvalidateConfigCache()
-		self._configCache = nil;
 	end
 
 end -- Widget factory

--- a/ConsolePort_Bar/Model/Utils.lua
+++ b/ConsolePort_Bar/Model/Utils.lua
@@ -158,7 +158,7 @@ do -- Widget factory
 
 	function env:Release(widget, release)
 		ActiveWidgets[widget] = nil;
-		self:InvalidateConfigCache()
+		self:InvalidateConfigCache();
 		(release or HideAndClearAnchors)(widget);
 		if widget.OnRelease then
 			widget:OnRelease();

--- a/ConsolePort_Bar/View/Config/Loadout.lua
+++ b/ConsolePort_Bar/View/Config/Loadout.lua
@@ -89,6 +89,9 @@ local function ReleaseSetting(_, self)
 	if self.Reset then
 		self:Reset()
 	end
+	if self.deleteButtonPool then
+		self.deleteButtonPool:ReleaseAll()
+	end
 	self.children, self.owner, self.pendingChildren = nil, nil, nil;
 end
 
@@ -494,7 +497,9 @@ function Mutable:OnDelete(path, owner)
 	env(path, nil)
 	self.controller:Remove(GetEndpoint(path))
 	env:TriggerPathEvent(self.variableID, 'OnDelete', path)
-	self.children[owner] = nil;
+	if self.children then
+		self.children[owner] = nil;
+	end
 	owner:Hide()
 end
 

--- a/ConsolePort_Bar/View/Config/Loadout.lua
+++ b/ConsolePort_Bar/View/Config/Loadout.lua
@@ -1322,7 +1322,6 @@ end
 ---------------------------------------------------------------
 function Loadout:Update()
 	self.updated = false;
-	env:InvalidateConfigCache()
 	self:MarkDirty()
 	self:Draw()
 end

--- a/ConsolePort_Bar/View/Config/Loadout.lua
+++ b/ConsolePort_Bar/View/Config/Loadout.lua
@@ -89,7 +89,7 @@ local function ReleaseSetting(_, self)
 	if self.Reset then
 		self:Reset()
 	end
-	self.children, self.owner = nil, nil;
+	self.children, self.owner, self.pendingChildren = nil, nil, nil;
 end
 
 local function GetEndpoint(path)
@@ -98,6 +98,9 @@ end
 
 function LoadoutSetting:OnExpandOrCollapse()
 	local isChecked = self:GetChecked();
+	if isChecked then
+		self:MaterializeChildren()
+	end
 	self:ToggleChildren(isChecked)
 	self:UpdateIcon(isChecked)
 end
@@ -110,8 +113,38 @@ function LoadoutSetting:UpdateIcon(isChecked)
 	end
 end
 
+function LoadoutSetting:CountPendingChildren()
+	local pending = self.pendingChildren;
+	if not pending then return 0 end;
+	local count = 0;
+	for _, datapoint in pairs(pending.children) do
+		if not datapoint.hide then
+			count = count + 1;
+		end
+	end
+	return count;
+end
+
+-- Answers from pending data when the subtree isn't built yet.
 function LoadoutSetting:HasChildren()
-	return self.children and next(self.children) ~= nil;
+	if self.children and next(self.children) ~= nil then
+		return true;
+	end
+	return self:CountPendingChildren() > 0;
+end
+
+-- Builds one level; new children start collapsed and defer in turn.
+function LoadoutSetting:MaterializeChildren()
+	local pending = self.pendingChildren;
+	if not pending then return end;
+	local count = self:CountPendingChildren();
+	self.pendingChildren = nil;
+	if count == 0 then return end;
+
+	-- Make room so the subtree slots in beneath this widget.
+	local owner = self:GetParent();
+	owner:NudgeLayoutIndex(self.layoutIndex + 1, count)
+	owner:DrawChildren(self, pending.path, pending.children, CreateCounter(self.layoutIndex), pending.depth)
 end
 
 function LoadoutSetting:AddChild(child)
@@ -472,6 +505,10 @@ end
 
 function Mutable:ToggleDeleteButtons()
 	self.deleteButtonPool:ReleaseAll()
+	-- Runs before OnExpandOrCollapse, so the subtree may still be pending.
+	if self:GetChecked() then
+		self:MaterializeChildren()
+	end
 	if self:GetChecked() and self.children then
 		for child in pairs(self.children) do
 			local button = self.deleteButtonPool:Acquire()
@@ -1232,6 +1269,12 @@ function Loadout:DrawInterface(parent, path, interface, layoutIndex, depth)
 end
 
 function Loadout:DrawChildren(parent, path, children, layoutIndex, depth)
+	-- Collapsed subtrees are invisible; build on first expand instead.
+	if not parent:GetChecked() then
+		parent.pendingChildren = { path = path, children = children, depth = depth };
+		parent:UpdateIcon(false)
+		return;
+	end
 	for child, datapoint in db.table.spairs(children, DisplaySort) do
 		self:DrawChild(parent, path, child, datapoint, layoutIndex, depth)
 	end
@@ -1279,6 +1322,7 @@ end
 ---------------------------------------------------------------
 function Loadout:Update()
 	self.updated = false;
+	env:InvalidateConfigCache()
 	self:MarkDirty()
 	self:Draw()
 end

--- a/ConsolePort_Config/View/Config/Config.lua
+++ b/ConsolePort_Config/View/Config/Config.lua
@@ -267,6 +267,11 @@ function Config:OnShowDelayed()
 	end
 end
 
+function Config:OnHide()
+	CPCombatHideMixin.OnHide(self)
+	self:CancelPendingSearches()
+end
+
 function Config:SetDefaultClosures()
 	self:ReleaseClosures()
 	for button, delta in pairs(self.PanelSelectDelta) do
@@ -416,20 +421,10 @@ function Config:OnSearch(text)
 	if text then
 		local _, right = self.Container:GetLists()
 		local results = right:GetDataProvider()
+		self:CancelPendingSearches()
 		results:Flush()
-		-- Stale matches would otherwise land in the provider we just emptied.
-		for _, panel in env:EnumeratePanels() do
-			if panel.CancelPendingSearch then
-				panel:CancelPendingSearch()
-			end
-		end
-		if self._searchTimer then
-			self._searchTimer:Cancel()
-			self._searchTimer = nil
-		end
-		-- Deferred so the keystroke itself stays cheap.
 		self._searchTimer = C_Timer.NewTimer(0, function()
-			self._searchTimer = nil
+			self._searchTimer = nil;
 			for _, panel in env:EnumeratePanels() do
 				panel:OnSearch(text, results, results.node:GetSize() + 1)
 			end
@@ -440,19 +435,21 @@ function Config:OnSearch(text)
 		end)
 		return;
 	end
-	-- Search cleared; stop pending and in-flight rendering.
+	self:CancelPendingSearches()
+	local currentPanel = self:GetCurrentPanel()
+	if currentPanel then
+		ExecuteFrameScript(currentPanel, 'OnShow')
+	end
+end
+
+function Config:CancelPendingSearches()
 	if self._searchTimer then
-		self._searchTimer:Cancel()
-		self._searchTimer = nil
+		self._searchTimer = self._searchTimer:Cancel();
 	end
 	for _, panel in env:EnumeratePanels() do
 		if panel.CancelPendingSearch then
 			panel:CancelPendingSearch()
 		end
-	end
-	local currentPanel = self:GetCurrentPanel()
-	if currentPanel then
-		ExecuteFrameScript(currentPanel, 'OnShow')
 	end
 end
 

--- a/ConsolePort_Config/View/Config/Config.lua
+++ b/ConsolePort_Config/View/Config/Config.lua
@@ -425,9 +425,10 @@ function Config:OnSearch(text)
 		end
 		if self._searchTimer then
 			self._searchTimer:Cancel()
+			self._searchTimer = nil
 		end
 		-- Deferred so the keystroke itself stays cheap.
-		self._searchTimer = C_Timer.After(0, function()
+		self._searchTimer = C_Timer.NewTimer(0, function()
 			self._searchTimer = nil
 			for _, panel in env:EnumeratePanels() do
 				panel:OnSearch(text, results, results.node:GetSize() + 1)

--- a/ConsolePort_Config/View/Config/Config.lua
+++ b/ConsolePort_Config/View/Config/Config.lua
@@ -468,6 +468,8 @@ function Config:FinalizeSearch(results, stagings)
 		results:Insert(env.Elements.Title:New(SEARCH))
 		results:Insert(env.Elements.Results:New(SETTINGS_SEARCH_NOTHING_FOUND:gsub('%. ', '.\n')))
 	end
+	local _, right = self.Container:GetLists()
+	right:GetScrollView():ReinitializeFrames()
 end
 
 function Config:CancelPendingSearches()

--- a/ConsolePort_Config/View/Config/Config.lua
+++ b/ConsolePort_Config/View/Config/Config.lua
@@ -417,14 +417,37 @@ function Config:OnSearch(text)
 		local _, right = self.Container:GetLists()
 		local results = right:GetDataProvider()
 		results:Flush()
+		-- Stale matches would otherwise land in the provider we just emptied.
 		for _, panel in env:EnumeratePanels() do
-			panel:OnSearch(text, results, results.node:GetSize() + 1)
+			if panel.CancelPendingSearch then
+				panel:CancelPendingSearch()
+			end
 		end
-		if results:IsEmpty() then
-			results:Insert(env.Elements.Title:New(SEARCH))
-			results:Insert(env.Elements.Results:New(SETTINGS_SEARCH_NOTHING_FOUND:gsub('%. ', '.\n')))
+		if self._searchTimer then
+			self._searchTimer:Cancel()
 		end
+		-- Deferred so the keystroke itself stays cheap.
+		self._searchTimer = C_Timer.After(0, function()
+			self._searchTimer = nil
+			for _, panel in env:EnumeratePanels() do
+				panel:OnSearch(text, results, results.node:GetSize() + 1)
+			end
+			if results:IsEmpty() then
+				results:Insert(env.Elements.Title:New(SEARCH))
+				results:Insert(env.Elements.Results:New(SETTINGS_SEARCH_NOTHING_FOUND:gsub('%. ', '.\n')))
+			end
+		end)
 		return;
+	end
+	-- Search cleared; stop pending and in-flight rendering.
+	if self._searchTimer then
+		self._searchTimer:Cancel()
+		self._searchTimer = nil
+	end
+	for _, panel in env:EnumeratePanels() do
+		if panel.CancelPendingSearch then
+			panel:CancelPendingSearch()
+		end
 	end
 	local currentPanel = self:GetCurrentPanel()
 	if currentPanel then

--- a/ConsolePort_Config/View/Config/Config.lua
+++ b/ConsolePort_Config/View/Config/Config.lua
@@ -47,8 +47,9 @@ function Panel:SetEnabled(enabled)
 	self.navButton:SetEnabled(enabled)
 end
 
-function Panel:OnSearch(text, dataProvider)
-	-- query string, dataprovider to add results to
+function Panel:OnSearch(text, onCompleted)
+	-- query string, callback expecting (panel, staging dataprovider or nil)
+	onCompleted(self, nil)
 end
 
 function Panel:OnDefaults()
@@ -425,13 +426,7 @@ function Config:OnSearch(text)
 		results:Flush()
 		self._searchTimer = C_Timer.NewTimer(0, function()
 			self._searchTimer = nil;
-			for _, panel in env:EnumeratePanels() do
-				panel:OnSearch(text, results, results.node:GetSize() + 1)
-			end
-			if results:IsEmpty() then
-				results:Insert(env.Elements.Title:New(SEARCH))
-				results:Insert(env.Elements.Results:New(SETTINGS_SEARCH_NOTHING_FOUND:gsub('%. ', '.\n')))
-			end
+			self:DispatchSearch(text, results)
 		end)
 		return;
 	end
@@ -442,7 +437,41 @@ function Config:OnSearch(text)
 	end
 end
 
+function Config:DispatchSearch(text, results)
+	local pending, stagings = {}, {};
+	self._pendingSearch = pending;
+	for _, panel in env:EnumeratePanels() do
+		pending[panel] = true;
+	end
+	local function onCompleted(panel, staging)
+		if self._pendingSearch ~= pending then return end;
+		pending[panel] = nil;
+		stagings[panel] = staging;
+		if not next(pending) then
+			self._pendingSearch = nil;
+			self:FinalizeSearch(results, stagings)
+		end
+	end
+	for _, panel in env:EnumeratePanels() do
+		panel:OnSearch(text, onCompleted)
+	end
+end
+
+function Config:FinalizeSearch(results, stagings)
+	for _, panel in env:EnumeratePanels() do
+		local staging = stagings[panel];
+		if staging then
+			env.SettingsRenderer.Splice(staging, results)
+		end
+	end
+	if results:IsEmpty() then
+		results:Insert(env.Elements.Title:New(SEARCH))
+		results:Insert(env.Elements.Results:New(SETTINGS_SEARCH_NOTHING_FOUND:gsub('%. ', '.\n')))
+	end
+end
+
 function Config:CancelPendingSearches()
+	self._pendingSearch = nil;
 	if self._searchTimer then
 		self._searchTimer = self._searchTimer:Cancel();
 	end

--- a/ConsolePort_Config/View/Guide/OverviewEditor.lua
+++ b/ConsolePort_Config/View/Guide/OverviewEditor.lua
@@ -296,11 +296,15 @@ end
 function Editor:HandleBindingSearch(text, results)
 	if text then
 		results:Flush()
-		self:OnSearch(text, results)
-		if results:IsEmpty() then
-			results:Insert(env.Elements.Title:New(SEARCH))
-			results:Insert(env.Elements.Results:New(SETTINGS_SEARCH_NOTHING_FOUND:gsub('%. ', '.\n')))
-		end
+		self:OnSearch(text, function(_, staging)
+			if staging then
+				self.Splice(staging, results)
+			end
+			if results:IsEmpty() then
+				results:Insert(env.Elements.Title:New(SEARCH))
+				results:Insert(env.Elements.Results:New(SETTINGS_SEARCH_NOTHING_FOUND:gsub('%. ', '.\n')))
+			end
+		end)
 		return;
 	end
 	self:SetEditType(nil)

--- a/ConsolePort_Config/View/Settings/Renderer.lua
+++ b/ConsolePort_Config/View/Settings/Renderer.lua
@@ -7,6 +7,8 @@ local Renderer = {}; env.SettingsRenderer = Renderer;
 -----------------------------------------------------------
 local SEP = GRAY_FONT_COLOR:WrapTextInColorCode(' | ');
 
+local SEARCH_CHUNK_BUDGET_MS = 4;
+
 function Renderer.MakeDivider()
 	return env.Elements.Divider:New(8)
 end
@@ -192,11 +194,12 @@ function Renderer:OnSearch(text, provider, startIndex) text = text:lower();
 		local name  = field.name;
 		local excl  = field.excludeSearch;
 
-		return not excl and (( name and MinEditDistance(name:lower(), text) < 3 )
-			or TestString(name)
+		-- Cheap tests first; MinEditDistance is the expensive fallback.
+		return not excl and (TestString(name)
 			or TestString(field.desc)
 			or TestString(field.note)
-			or TestString(field.list));
+			or TestString(field.list)
+			or (name and MinEditDistance(name:lower(), text) < 3));
 	end
 
 	for main, group in env.table.spairs(interface) do
@@ -210,18 +213,61 @@ function Renderer:OnSearch(text, provider, startIndex) text = text:lower();
 	end
 
 	local needsDeviceEdit = false;
+
+	-- Broad queries can match most of the list. Only data is inserted, into a
+	-- virtualized provider, so spreading across frames is safe.
+	self:CancelPendingSearch()
+
+	local queue = {};
 	for main, group in env.table.spairs(results) do
-		if self:Render(provider, main, group, false, false, true) then
-			needsDeviceEdit = true;
+		tinsert(queue, {main = main, group = group})
+	end
+
+	local index = 1;
+	local function RenderChunk()
+		local deadline = debugprofilestop() + SEARCH_CHUNK_BUDGET_MS;
+		repeat -- at least one group per pass, to guarantee progress
+			local entry = queue[index];
+			if not entry then break end;
+			if self:Render(provider, entry.main, entry.group, false, false, true) then
+				needsDeviceEdit = true;
+			end
+			index = index + 1;
+		until index > #queue or debugprofilestop() >= deadline;
+		return index > #queue;
+	end
+
+	local function Finish()
+		if needsDeviceEdit then
+			provider:InsertAtIndex(self.MakeDivider(), startIndex)
+			provider:InsertAtIndex(env.Elements.DeviceEdit:New(), startIndex)
+		end
+		if next(results) then
+			provider:InsertAtIndex(self.MakeTitle(self:GetSearchTitle()), startIndex)
 		end
 	end
 
-	if needsDeviceEdit then
-		provider:InsertAtIndex(self.MakeDivider(), startIndex)
-		provider:InsertAtIndex(env.Elements.DeviceEdit:New(), startIndex)
+	-- Synchronous first chunk, so the caller's IsEmpty check sees results.
+	if RenderChunk() then
+		return Finish();
 	end
-	if next(results) then
-		provider:InsertAtIndex(self.MakeTitle(self:GetSearchTitle()), startIndex)
+
+	local driver = self._searchDriver;
+	if not driver then
+		driver = CreateFrame('Frame');
+		self._searchDriver = driver;
+	end
+	driver:SetScript('OnUpdate', function()
+		if RenderChunk() then
+			driver:SetScript('OnUpdate', nil)
+			Finish()
+		end
+	end)
+end
+
+function Renderer:CancelPendingSearch()
+	if self._searchDriver then
+		self._searchDriver:SetScript('OnUpdate', nil)
 	end
 end
 

--- a/ConsolePort_Config/View/Settings/Renderer.lua
+++ b/ConsolePort_Config/View/Settings/Renderer.lua
@@ -172,7 +172,7 @@ function Renderer:Render(provider, title, data, preferCollapsed, useDeviceEdit, 
 	return hasDeviceSettings and not useDeviceEdit;
 end
 
-function Renderer:OnSearch(text, provider, startIndex) text = text:lower();
+function Renderer:OnSearch(text, onCompleted) text = text:lower();
 	local interface = self:GetIndex()
 	local MinEditDistance = CPAPI.MinEditDistance;
 
@@ -212,16 +212,30 @@ function Renderer:OnSearch(text, provider, startIndex) text = text:lower();
 		end
 	end
 
-	local needsDeviceEdit = false;
-
-	-- Broad queries can match most of the list. Only data is inserted, into a
-	-- virtualized provider, so spreading across frames is safe.
 	self:CancelPendingSearch()
 
-	local queue = {};
+	local queue, needsDeviceEdit = {}, false;
 	for main, group in env.table.spairs(results) do
 		tinsert(queue, {main = main, group = group})
+		for _, dp in ipairs(group) do
+			if dp.field.path then
+				needsDeviceEdit = true;
+			end
+		end
 	end
+
+	if not next(queue) then
+		return onCompleted(self, nil);
+	end
+
+	local staging = CreateTreeDataProvider()
+	staging:Insert(self.MakeTitle(self:GetSearchTitle()))
+	if needsDeviceEdit then
+		staging:Insert(env.Elements.DeviceEdit:New())
+		staging:Insert(self.MakeDivider())
+	end
+
+	local preferCollapsed, useDeviceEdit, flattened = false, false, true;
 
 	local index = 1;
 	local function RenderChunk()
@@ -229,33 +243,20 @@ function Renderer:OnSearch(text, provider, startIndex) text = text:lower();
 		repeat -- at least one group per pass, to guarantee progress
 			local entry = queue[index];
 			if not entry then break end;
-			if self:Render(provider, entry.main, entry.group, false, false, true) then
-				needsDeviceEdit = true;
-			end
+			self:Render(staging, entry.main, entry.group, preferCollapsed, useDeviceEdit, flattened)
 			index = index + 1;
 		until index > #queue or debugprofilestop() >= deadline;
 		return index > #queue;
 	end
 
-	local function Finish()
-		if needsDeviceEdit then
-			provider:InsertAtIndex(self.MakeDivider(), startIndex)
-			provider:InsertAtIndex(env.Elements.DeviceEdit:New(), startIndex)
-		end
-		if next(results) then
-			provider:InsertAtIndex(self.MakeTitle(self:GetSearchTitle()), startIndex)
-		end
-	end
-
-	-- Synchronous first chunk, so the caller's IsEmpty check sees results.
 	if RenderChunk() then
-		return Finish();
+		return onCompleted(self, staging);
 	end
 
 	self._searchTicker = C_Timer.NewTicker(0, function(ticker)
 		if RenderChunk() then
 			self._searchTicker = ticker:Cancel();
-			Finish()
+			onCompleted(self, staging)
 		end
 	end)
 end
@@ -263,6 +264,21 @@ end
 function Renderer:CancelPendingSearch()
 	if self._searchTicker then
 		self._searchTicker = self._searchTicker:Cancel();
+	end
+end
+
+do  local function SpliceNode(source, target)
+		for _, node in ipairs(source:GetNodes()) do
+			local copy = target:Insert(node:GetData())
+			if node:IsCollapsed() then
+				copy:SetCollapsed(true)
+			end
+			SpliceNode(node, copy)
+		end
+	end
+
+	function Renderer.Splice(staging, target)
+		SpliceNode(staging:GetRootNode(), target:GetRootNode())
 	end
 end
 

--- a/ConsolePort_Config/View/Settings/Renderer.lua
+++ b/ConsolePort_Config/View/Settings/Renderer.lua
@@ -252,22 +252,19 @@ function Renderer:OnSearch(text, provider, startIndex) text = text:lower();
 		return Finish();
 	end
 
-	local driver = self._searchDriver;
-	if not driver then
-		driver = CreateFrame('Frame');
-		self._searchDriver = driver;
-	end
-	driver:SetScript('OnUpdate', function()
+	self._searchTicker = C_Timer.NewTicker(0, function(ticker)
 		if RenderChunk() then
-			driver:SetScript('OnUpdate', nil)
+			ticker:Cancel()
+			self._searchTicker = nil
 			Finish()
 		end
 	end)
 end
 
 function Renderer:CancelPendingSearch()
-	if self._searchDriver then
-		self._searchDriver:SetScript('OnUpdate', nil)
+	if self._searchTicker then
+		self._searchTicker:Cancel()
+		self._searchTicker = nil
 	end
 end
 

--- a/ConsolePort_Config/View/Settings/Renderer.lua
+++ b/ConsolePort_Config/View/Settings/Renderer.lua
@@ -254,8 +254,7 @@ function Renderer:OnSearch(text, provider, startIndex) text = text:lower();
 
 	self._searchTicker = C_Timer.NewTicker(0, function(ticker)
 		if RenderChunk() then
-			ticker:Cancel()
-			self._searchTicker = nil
+			self._searchTicker = ticker:Cancel();
 			Finish()
 		end
 	end)
@@ -263,8 +262,7 @@ end
 
 function Renderer:CancelPendingSearch()
 	if self._searchTicker then
-		self._searchTicker:Cancel()
-		self._searchTicker = nil
+		self._searchTicker = self._searchTicker:Cancel();
 	end
 end
 

--- a/ConsolePort_Config/Widget/Scroll/Scroll.lua
+++ b/ConsolePort_Config/Widget/Scroll/Scroll.lua
@@ -133,7 +133,13 @@ function CPScrollBoxSettingsTree:InitDefault()
 		if ( info.xml ~= XML_SETTING_TEMPLATE ) then
 			return factory(info.xml, info.init)
 		end
-		SettingFactory(scrollView, info)
+		if scrollView:IsAcquireLocked() then
+			-- real acquisition; use hacky pooling by data type
+			SettingFactory(scrollView, info)
+		else
+			-- probe for template and initializer; must not create frames
+			factory(info.xml, info.init)
+		end
 	end)
 
 	-- Not entirely sure why this override is necessary, but without

--- a/ConsolePort_Config/Widget/Scroll/Scroll.lua
+++ b/ConsolePort_Config/Widget/Scroll/Scroll.lua
@@ -350,7 +350,6 @@ function CPLoadoutContainerMixin:UpdateCollections()
 		if not isSearchActive then
 			return true;
 		end
-		local id = Entry.UnpackID(entry);
 		-- Titles come from C calls and don't change mid-session.
 		if not self._titleCache then self._titleCache = {} end;
 		local cache = self._titleCache[data.name];
@@ -358,10 +357,10 @@ function CPLoadoutContainerMixin:UpdateCollections()
 			cache = {};
 			self._titleCache[data.name] = cache;
 		end
-		local title = cache[id];
+		local title = cache[entry];
 		if title == nil then
-			title = data.title(id);
-			cache[id] = title or false;
+			title = data.title(Entry.UnpackID(entry));
+			cache[entry] = title or false;
 		end
 		if not title then
 			return false;

--- a/ConsolePort_Config/Widget/Scroll/Scroll.lua
+++ b/ConsolePort_Config/Widget/Scroll/Scroll.lua
@@ -360,7 +360,7 @@ function CPLoadoutContainerMixin:UpdateCollections()
 		local title = cache[entry];
 		if title == nil then
 			title = data.title(Entry.UnpackID(entry));
-			cache[entry] = title or false;
+			cache[entry] = title;
 		end
 		if not title then
 			return false;

--- a/ConsolePort_Config/Widget/Scroll/Scroll.lua
+++ b/ConsolePort_Config/Widget/Scroll/Scroll.lua
@@ -296,6 +296,8 @@ function CPLoadoutContainerMixin:OnSearch(text)
 end
 
 function CPLoadoutContainerMixin:RefreshCollections()
+	-- Collection data may have changed.
+	self._titleCache = nil;
 	if not self.Collections or self:GetDataProvider():IsEmpty() then
 		return self:UpdateCollections()
 	end
@@ -348,7 +350,19 @@ function CPLoadoutContainerMixin:UpdateCollections()
 		if not isSearchActive then
 			return true;
 		end
-		local title = data.title(Entry.UnpackID(entry));
+		local id = Entry.UnpackID(entry);
+		-- Titles come from C calls and don't change mid-session.
+		if not self._titleCache then self._titleCache = {} end;
+		local cache = self._titleCache[data.name];
+		if not cache then
+			cache = {};
+			self._titleCache[data.name] = cache;
+		end
+		local title = cache[id];
+		if title == nil then
+			title = data.title(id);
+			cache[id] = title or false;
+		end
 		if not title then
 			return false;
 		end

--- a/ConsolePort_Config/Widget/Templates/Elements.lua
+++ b/ConsolePort_Config/Widget/Templates/Elements.lua
@@ -278,6 +278,7 @@ function Setting:OnRelease()
 end
 
 function Setting:OnDependencyChanged()
+	if not self.metaData then return end;
 	local isShown = not self.metaData.hide;
 	local newExtent = isShown and self.size.y or 0;
 	self:GetElementData():GetData().extent = newExtent;


### PR DESCRIPTION
Continuation of #191 (thanks @waldnercharles), with fixes from review and testing on top. Original commits included as-is.

### Kept from #191
- Chunked search rendering in the config
- Cheaper string matching in settings search
- Title cache for loadout search
- Lazy subtrees in the action bar designer
- Various micro-optimizations

### Changed
- Search results are staged and spliced in panel order to prevent mixups when multiple panels have matches
- Pending searches are cancelled when the config hides
- Hotkey rendering is debounced, action button scan moved to a weak cache in the hotkey handler
- Data fields share metatables with their prototype instead of copying them
- Failed title lookups retry instead of getting cached
- Modifier combos are generated recursively (no hardcoded modifier count)

### Reverted
- Action button scan cache in the model (broke hotkey discovery for LOD addons)
- Bar configuration memoization (never got a cache hit)

### Bug fixes
- Disabling hotkey rendering applies without a reload
- Settings tree leaked pooled frames on factory probes, causing blank entries in the config
- Stale delete buttons in the bar loadout could delete the wrong element