### PR TITLE
Fix unit hotkey display mismatch

### DIFF
--- a/ConsolePort/Controller/Securescan.lua
+++ b/ConsolePort/Controller/Securescan.lua
@@ -50,6 +50,29 @@ do	local HasScript, GetScript = Scan.HasScript, Scan.GetScript;
 	end
 end
 
+---------------------------------------------------------------
+-- Unit frame attribution
+---------------------------------------------------------------
+-- Keeps the unit frame cache correct when secure headers
+-- reassign unit attributes without firing a scanned event.
+local HookUnitFrame;
+do	local hooked = {};
+	local function OnUnitChanged(frame, attribute)
+		if ( attribute ~= 'unit' ) then return end;
+		local unit = GetUnitForFrame(frame)
+		if ( Cache[Widgets.UnitFrames][frame] ~= unit ) then
+			Cache[Widgets.UnitFrames][frame] = unit;
+			Scan:QueueAttributionUpdate()
+		end
+	end
+	HookUnitFrame = function(frame)
+		if not hooked[frame] then
+			hooked[frame] = true;
+			frame:HookScript('OnAttributeChanged', OnUnitChanged)
+		end
+	end
+end
+
 local ScanGlobal, ScanFrames;
 do	local EnumerateFrames, Scrub, IsProtected = EnumerateFrames, CPAPI.Scrub, Scan.IsProtected;
 	ScanFrames = function(collect, node, iterator, includeAll)
@@ -74,6 +97,9 @@ do	local EnumerateFrames, Scrub, IsProtected = EnumerateFrames, CPAPI.Scrub, Sca
 		Cache[Widgets.Any][node] = false;
 		if widgetType then
 			Cache[widgetType][node] = value;
+			if ( widgetType == Widgets.UnitFrames ) then
+				HookUnitFrame(node)
+			end
 		end
 	end
 
@@ -118,6 +144,10 @@ Scan.CINEMATIC_STOP        = Scan.GROUP_ROSTER_UPDATE;
 ---------------------------------------------------------------
 Scan.Refresh = ScanGlobal;
 Scan.Execute = ScanFrames;
+
+Scan.QueueAttributionUpdate = CPAPI.Debounce(function(self)
+	db:TriggerEvent('OnScanUpdate', Widgets.UnitFrames, Cache[Widgets.UnitFrames])
+end, Scan)
 
 function Scan:RegisterCallback(widgetType, callback, owner)
 	widgetType = widgetType or Widgets.Any;

--- a/ConsolePort/Controller/UnitHotkeys.lua
+++ b/ConsolePort/Controller/UnitHotkeys.lua
@@ -70,7 +70,7 @@ end
 local UH    = Mixin(CPAPI.EventHandler(ConsolePortEasyMotionButton, {'PLAYER_ENTERING_WORLD'}), CPAPI.SecureEnvironmentMixin)
 local Scan  = db.Scan;
 local Input = ConsolePortEasyMotionInput;
-UH.UnitDrivers, UH.UnitFrames = {}, {};
+UH.Assignments, UH.UnitDrivers, UH.UnitFrames = {}, {}, {};
 
 UH:Run([[bindRef = %q;
 	-- Unit and binding tables
@@ -156,15 +156,17 @@ UH:CreateEnvironment({
 
 	AssignUnits = [[
 		lookup = wipe(lookup)
+		local assignments = '';
 		for i, unit in ipairs(sorted) do
 			local binding = sequence[i];
 			if binding then
 				lookup[binding] = unit;
 				if UnitExists(unit) then
-					self:::AssignUnit(binding, unit)
+					assignments = assignments .. binding .. ' ' .. unit .. ';';
 				end
 			end
 		end
+		self:::SetAssignments(assignments)
 	]];
 
 	GetCommand = [[
@@ -403,15 +405,18 @@ db:RegisterCallbacks(UH.OnDisplaySettingsChanged, UH,
 ---------------------------------------------------------------
 -- Frontend frame tracking
 ---------------------------------------------------------------
-function UH:AssignUnit(binding, unitID)
-	self.UnitDrivers[unitID] = binding;
+function UH:SetAssignments(assignments)
+	local active = wipe(self.Assignments);
+	for binding, unitID in assignments:gmatch('(%d+) ([^;]+);') do
+		active[unitID] = tonumber(binding);
+	end
 	self:QueueUnitFrameRefresh()
 end
 
 function UH:RefreshUnitFrames()
 	local cache = Scan:GetCache(Scan.UnitFrames)
 	for frame, unitID in pairs(cache) do
-		if self.UnitDrivers[unitID] then
+		if self.Assignments[unitID] then
 			self:AddTrackedUnitFrame(unitID, frame)
 		end
 	end
@@ -451,7 +456,7 @@ function UH:GetUnitFramesForUnit(unitID)
 end
 
 function UH:GetActiveUnitIDs()
-	return pairs(tFilter(self.UnitDrivers, tonumber))
+	return pairs(self.Assignments)
 end
 
 function UH:GetNamePlateForUnit(unitID)

--- a/ConsolePort/Utils/Utils.lua
+++ b/ConsolePort/Utils/Utils.lua
@@ -395,7 +395,10 @@ end
 -- Debounce
 ---------------------------------------------------------------
 do local __tCount, __tID, __tTime = 0, 'task', '__time_';
-	local function Execute(self, task, callback)
+	local function Execute(self, task, timer, callback)
+		if self[timer] and self[timer] > GetTime() then
+			self[timer] = nil;
+		end
 		if not self[task] then
 			self[task] = true;
 			RunNextFrame(callback)
@@ -418,7 +421,7 @@ do local __tCount, __tID, __tTime = 0, 'task', '__time_';
 		local task    = __tID .. __tCount;
 		local timer   = task  .. __tTime;
 		local handler = GenerateClosure(Handler, owner, task, timer, callback, {...})
-		local execute = GenerateClosure(Execute, owner, task, handler)
+		local execute = GenerateClosure(Execute, owner, task, timer, handler)
 		local cancel  = GenerateClosure(Cancel,  owner, task, timer)
 		return setmetatable({
 			Execute = execute;


### PR DESCRIPTION
This pull request introduces improvements to the unit frame attribution and assignment system, ensuring more accurate tracking and updating of unit frames when their attributes change. It also refactors how unit assignments are managed and tracked, and makes enhancements to the debounce utility for more robust task scheduling.

**Unit Frame Attribution & Assignment Improvements:**

* Added a `HookUnitFrame` function in `Securescan.lua` to hook into unit frame attribute changes, ensuring the cache stays consistent when unit attributes are reassigned without explicit events. This helps maintain accurate unit-to-frame mappings.
* Modified the cache update logic to invoke `HookUnitFrame` when a unit frame is detected, ensuring all relevant frames are properly tracked.
* Introduced `Scan.QueueAttributionUpdate`, a debounced function that triggers an update event when unit frame attributions change, improving update efficiency and accuracy.

**Refactoring Unit Assignment Management:**

* Refactored unit assignment tracking in `UnitHotkeys.lua` by replacing the previous `UnitDrivers` approach with a new `Assignments` table, and updated related methods to use this new structure for better clarity and maintainability.
* Updated the environment assignment logic to build and set assignments as a single string, which is then parsed and applied in the new `SetAssignments` method.

**Debounce Utility Enhancements:**

* Updated the debounce utility in `Utils.lua` to better handle timing by checking and resetting timers, ensuring tasks are only executed when appropriate and preventing redundant executions.