### PR TITLE
Fix frame scan performance

### DIFF
--- a/ConsolePort/Controller/Securescan.lua
+++ b/ConsolePort/Controller/Securescan.lua
@@ -38,14 +38,15 @@ do	local HasScript, GetScript = Scan.HasScript, Scan.GetScript;
 	end
 
 	function GetUnitForFrame(frame)
-		if (( IsUnitButton(frame) or IsClickType(frame, 'target')) and GetRaw(frame, 'unit')) then
+		if ( GetRaw(frame, 'unit') and ( IsUnitButton(frame) or IsClickType(frame, 'target') )) then
 			return GetModifiedUnit(frame)
 		end
 	end
 
 	function GetActionForFrame(frame)
-		if ( IsActionButton(frame) or IsClickType(frame, 'action')) then
-			return tonumber(GetAttribute(frame, 'action'))
+		local action = tonumber(GetAttribute(frame, 'action'))
+		if ( action and ( IsActionButton(frame) or IsClickType(frame, 'action') )) then
+			return action;
 		end
 	end
 end
@@ -81,11 +82,14 @@ do	local EnumerateFrames, Scrub, IsProtected = EnumerateFrames, CPAPI.Scrub, Sca
 				if includeAll then
 					collect(node)
 				else
-					local unit, action = GetUnitForFrame(node), GetActionForFrame(node);
-					if unit and not action then
-						collect(node, Widgets.UnitFrames, unit)
-					elseif action then
+					local action = GetActionForFrame(node)
+					if action then
 						collect(node, Widgets.ActionBars, action)
+					else
+						local unit = GetUnitForFrame(node)
+						if unit then
+							collect(node, Widgets.UnitFrames, unit)
+						end
 					end
 				end
 			end

--- a/ConsolePort/Controller/Securescan.lua
+++ b/ConsolePort/Controller/Securescan.lua
@@ -76,48 +76,104 @@ end
 
 local ScanGlobal, ScanFrames;
 do	local EnumerateFrames, Scrub, IsProtected = EnumerateFrames, CPAPI.Scrub, Scan.IsProtected;
+	local debugprofilestop = debugprofilestop;
+	local SCAN_BUDGET_MS   = 1.5;
+	local SCAN_GRANULARITY = 100;
+
+	local function ClassifyNode(collect, node)
+		local action = GetActionForFrame(node)
+		if action then
+			collect(node, Widgets.ActionBars, action)
+		else
+			local unit = GetUnitForFrame(node)
+			if unit then
+				collect(node, Widgets.UnitFrames, unit)
+			end
+		end
+	end
+
 	ScanFrames = function(collect, node, iterator, includeAll)
 		while node do
 			if Scrub(IsProtected(node)) then
 				if includeAll then
 					collect(node)
 				else
-					local action = GetActionForFrame(node)
-					if action then
-						collect(node, Widgets.ActionBars, action)
-					else
-						local unit = GetUnitForFrame(node)
-						if unit then
-							collect(node, Widgets.UnitFrames, unit)
-						end
-					end
+					ClassifyNode(collect, node)
 				end
 			end
 			node = iterator(node)
 		end
 	end;
 
-	local function ScanLocal(node, widgetType, value)
-		Cache[Widgets.Any][node] = false;
+	local Staging = {};
+	for _, typeIndex in pairs(Widgets) do
+		Staging[typeIndex] = {};
+	end
+
+	local function StageNode(node, widgetType, value)
+		Staging[Widgets.Any][node] = false;
 		if widgetType then
-			Cache[widgetType][node] = value;
-			if ( widgetType == Widgets.UnitFrames ) then
-				HookUnitFrame(node)
-			end
+			Staging[widgetType][node] = value;
 		end
 	end
 
-	ScanGlobal = CPAPI.Debounce(function(self, collector)
+	local function CommitGlobalScan(self)
+		self:WipeCache()
+		for typeIndex, staged in pairs(Staging) do
+			local cache = Cache[typeIndex];
+			for node, value in pairs(staged) do
+				cache[node] = value;
+			end
+			wipe(staged)
+		end
+		for node in pairs(Cache[Widgets.UnitFrames]) do
+			HookUnitFrame(node)
+		end
+		self:FireCallbacks(Widgets.Any)
+	end
+
+	local function SliceGlobalScan(self)
+		local node, count = self.scanCursor, SCAN_GRANULARITY;
+		local expires = debugprofilestop() + SCAN_BUDGET_MS;
+		while node do
+			if Scrub(IsProtected(node)) then
+				ClassifyNode(StageNode, node)
+			end
+			node = EnumerateFrames(node)
+			count = count - 1;
+			if ( count <= 0 ) then
+				if ( debugprofilestop() > expires ) then
+					self.scanCursor = node;
+					return
+				end
+				count = SCAN_GRANULARITY;
+			end
+		end
+		self:StopGlobalScan()
+		if not InCombatLockdown() then
+			CommitGlobalScan(self)
+		end
+	end
+
+	function Scan:StartGlobalScan()
+		for _, staged in pairs(Staging) do
+			wipe(staged)
+		end
+		self.scanCursor = EnumerateFrames();
+		self:SetScript('OnUpdate', SliceGlobalScan)
+	end
+
+	function Scan:StopGlobalScan()
+		self.scanCursor = nil;
+		self:SetScript('OnUpdate', nil)
+	end
+
+	ScanGlobal = CPAPI.Debounce(function(self)
 		if InCombatLockdown() then
 			return CPAPI.Log('Raid cursor scan failed due to combat lockdown. Waiting for combat to end...')
 		end
-		for _, typeIndex in pairs(Widgets) do
-			wipe(Cache[typeIndex]);
-		end
-		self:WipeCache()
-		ScanFrames(collector, EnumerateFrames(), EnumerateFrames, false)
-		self:FireCallbacks(Widgets.Any)
-	end, Scan, ScanLocal);
+		self:StartGlobalScan()
+	end, Scan);
 end
 
 ---------------------------------------------------------------
@@ -131,6 +187,7 @@ end
 
 function Scan:PLAYER_REGEN_DISABLED()
 	ScanGlobal.Cancel()
+	self:StopGlobalScan()
 end
 
 function Scan:OnDataLoaded()

--- a/ConsolePort/Model/Game/Actionbar.lua
+++ b/ConsolePort/Model/Game/Actionbar.lua
@@ -106,6 +106,7 @@ do
 	local IGNORE_FRAMES     = ActionBarAPI.Lookup.Ignore;
 	local IsFrameWidget     = C_Widget.IsFrameWidget;
 	local Frame             = GetFrameMetatable().__index;
+	local Scrub             = CPAPI.Scrub;
 
 	-- Helpers:
 	local function GetContainer(this)
@@ -114,11 +115,9 @@ do
 	end
 
 	local function ValidateActionID(this)
-		local isProtected, type, action = CPAPI.Scrub(
-			Frame.IsProtected(this),
-			Frame.GetObjectType(this),
-			Frame.GetAttribute(this, 'action'))
-		return (isProtected and type and VALID_BUTTON_TYPE[type]) and action;
+		if not Scrub(Frame.IsProtected(this)) then return end
+		if not VALID_BUTTON_TYPE[Scrub(Frame.GetObjectType(this))] then return end
+		return Scrub(Frame.GetAttribute(this, 'action'))
 	end
 
 	local function IsActionButton(this, action)
@@ -138,16 +137,22 @@ do
 	end
 
 	-- Scanner:
-	local function FindActionButtons(callback, cache, this, sibling, ...)
-		if sibling then FindActionButtons(callback, cache, sibling, ...) end
+	local FindActionButtons;
+	local function ScanChildren(callback, cache, ...)
+		for i = 1, select('#', ...) do
+			FindActionButtons(callback, cache, (select(i, ...)))
+		end
+		return cache
+	end
+
+	function FindActionButtons(callback, cache, this)
 		if not IsFrameWidget(this) or Frame.IsForbidden(this) or IGNORE_FRAMES[this] then return cache end
 		-------------------------------------
 		local action = ValidateActionID(this)
 		if IsActionButton(this, action) and callback(cache, this, action) then
 			return cache
 		end
-		FindActionButtons(callback, cache, Frame.GetChildren(this))
-		return cache
+		return ScanChildren(callback, cache, Frame.GetChildren(this))
 	end
 
 	---------------------------------------------------------------


### PR DESCRIPTION
EnumerateFrames appears to have gained a lot of overhead in 12.1, so the full UI scan for raid cursor and unit hotkeys can no longer take place in a single frame. The enumeration has to be batched, meaning it will take a few frames before a full update is completed.