### PR TITLE
Replace EnumerateFrames with recursive container scan

### DIFF
--- a/ConsolePort/Controller/Securescan.lua
+++ b/ConsolePort/Controller/Securescan.lua
@@ -78,10 +78,9 @@ end
 -- Global scanning
 ---------------------------------------------------------------
 local ScanGlobal, ScanFrames;
-do	local EnumerateFrames, Scrub, IsProtected = EnumerateFrames, CPAPI.Scrub, Scan.IsProtected;
-	local debugprofilestop = debugprofilestop;
-	local SCAN_BUDGET_MS   = 1.5;
-	local SCAN_GRANULARITY = 10;
+do	local Scrub, IsProtected, IsForbidden, GetChildren =
+		CPAPI.Scrub, Scan.IsProtected, Scan.IsForbidden, Scan.GetChildren;
+	local SCAN_BUDGET = 500; -- nodes processed per frame
 
 	-- Classification
 	local function ClassifyNode(collect, node)
@@ -109,8 +108,8 @@ do	local EnumerateFrames, Scrub, IsProtected = EnumerateFrames, CPAPI.Scrub, Sca
 		end
 	end;
 
-	-- Caches
-	local Seen, StagedSeen, Discovered, Staging = {}, {}, {}, {};
+	-- Staging
+	local Staging = {};
 	for _, typeIndex in pairs(Widgets) do
 		Staging[typeIndex] = {};
 	end
@@ -122,87 +121,73 @@ do	local EnumerateFrames, Scrub, IsProtected = EnumerateFrames, CPAPI.Scrub, Sca
 		end
 	end
 
-	-- Discovery
-	local function StageDiscoveredNodes()
-		for node in pairs(Discovered) do
-			Discovered[node] = nil;
-			Seen[node] = true;
-			if Scrub(IsProtected(node)) then
-				ClassifyNode(StageNode, node)
-			end
-		end
-	end
-
 	-- Commit
 	local function CommitGlobalScan(self)
-		StageDiscoveredNodes()
-		for node in pairs(StagedSeen) do
-			StagedSeen[node] = nil;
-			Seen[node] = true;
-		end
-		local newNodes, unitChanges;
 		for typeIndex, staged in pairs(Staging) do
-			local cache = Cache[typeIndex];
+			local cache = wipe(Cache[typeIndex]);
 			for node, value in pairs(staged) do
-				if ( cache[node] ~= value ) then
-					cache[node] = value;
-					if ( typeIndex == Widgets.UnitFrames ) then
-						HookUnitFrame(node)
-						unitChanges = true;
-					else
-						newNodes = true;
-					end
-				end
+				cache[node] = value;
 			end
 			wipe(staged)
 		end
-		if newNodes then
-			self:FireCallbacks(Widgets.Any)
-		elseif unitChanges then
-			self:QueueAttributionUpdate()
+		for node in pairs(Cache[Widgets.UnitFrames]) do
+			HookUnitFrame(node)
+		end
+		self:FireCallbacks(Widgets.Any)
+	end
+
+	-- Depth-first walk of the UIParent tree, resumable across
+	-- frames when the node budget runs out.
+	local ScanStack, scanDepth = {}, 0;
+
+	local function PushChildren(...)
+		for i = 1, select('#', ...) do
+			local child = select(i, ...);
+			if child then
+				scanDepth = scanDepth + 1;
+				ScanStack[scanDepth] = child;
+			end
 		end
 	end
 
-	-- Sliced global scan
 	local function SliceGlobalScan(self)
-		local node, count = self.scanCursor, SCAN_GRANULARITY;
-		local expires = debugprofilestop() + SCAN_BUDGET_MS;
-		while node do
-			if not ( Seen[node] or StagedSeen[node] ) then
-				StagedSeen[node] = true;
+		local budget = SCAN_BUDGET;
+		while ( scanDepth > 0 and budget > 0 ) do
+			local node = ScanStack[scanDepth];
+			ScanStack[scanDepth] = nil;
+			scanDepth = scanDepth - 1;
+			budget = budget - 1;
+			if not Scrub(IsForbidden(node)) then
 				if Scrub(IsProtected(node)) then
 					ClassifyNode(StageNode, node)
 				end
-			end
-			node = EnumerateFrames(node)
-			count = count - 1;
-			if ( count <= 0 ) then
-				if ( debugprofilestop() >= expires ) then
-					self.scanCursor = node;
-					return
-				end
-				count = SCAN_GRANULARITY;
+				PushChildren(Scrub(GetChildren(node)))
 			end
 		end
-		self:StopGlobalScan()
-		if InCombatLockdown() then
-			self.scanQueued = true;
-		else
-			CommitGlobalScan(self)
+		if ( scanDepth == 0 ) then
+			self:StopGlobalScan()
+			if InCombatLockdown() then
+				self.scanQueued = true;
+			else
+				CommitGlobalScan(self)
+			end
 		end
 	end
 
 	-- Start / stop
-	-- Staging is not wiped here: a commit is the only consumer,
-	-- so anything staged belongs to an aborted scan, and keeping
-	-- it lets the restarted pass skip already-classified frames.
 	function Scan:StartGlobalScan()
-		self.scanCursor = EnumerateFrames();
+		for _, staged in pairs(Staging) do
+			wipe(staged)
+		end
+		wipe(ScanStack)
+		scanDepth = 1;
+		ScanStack[1] = UIParent;
+		self.scanActive = true;
 		self:SetScript('OnUpdate', SliceGlobalScan)
 	end
 
 	function Scan:StopGlobalScan()
-		self.scanCursor = nil;
+		self.scanActive = nil;
 		self:SetScript('OnUpdate', nil)
 	end
 
@@ -215,38 +200,6 @@ do	local EnumerateFrames, Scrub, IsProtected = EnumerateFrames, CPAPI.Scrub, Sca
 		self.scanQueued = nil;
 		self:StartGlobalScan()
 	end, Scan);
-
-	-----------------------------------------------------------
-	-- Discovery funnels
-	-----------------------------------------------------------
-	-- Scan passes skip frames they have already seen, so frames
-	-- that change role after their first classification are
-	-- requeued here.
-	--
-	-- SecureUnitButton_OnLoad runs on every
-	-- CompactUnitFrame_SetUnit and on setup of all non-compact
-	-- Blizzard unit frames.
-	--
-	-- RegisterUnitWatch covers addon frames spawned outside
-	-- secure group headers.
-
-	Scan.QueueDiscovery = CPAPI.Debounce(function(self)
-		if not next(Discovered) or InCombatLockdown() or self.scanCursor then return end;
-		CommitGlobalScan(self)
-	end, Scan)
-
-	local function QueueNodeDiscovery(node)
-		if not C_Widget.IsFrameWidget(node) or Scrub(node:IsForbidden()) then return end;
-		Discovered[node] = true;
-		Scan:QueueDiscovery()
-	end
-
-	hooksecurefunc('SecureUnitButton_OnLoad', QueueNodeDiscovery)
-	hooksecurefunc('RegisterUnitWatch', QueueNodeDiscovery)
-
-	function Scan:HasPendingDiscovery()
-		return next(Discovered) ~= nil;
-	end
 end
 
 ---------------------------------------------------------------
@@ -262,7 +215,7 @@ end
 
 function Scan:PLAYER_REGEN_DISABLED()
 	ScanGlobal.Cancel()
-	if self.scanCursor then
+	if self.scanActive then
 		self.scanQueued = true;
 		self:StopGlobalScan()
 	end
@@ -270,10 +223,7 @@ end
 
 function Scan:PLAYER_REGEN_ENABLED()
 	if self.scanQueued then
-		return ScanGlobal()
-	end
-	if self:HasPendingDiscovery() then
-		self:QueueDiscovery()
+		ScanGlobal()
 	end
 end
 

--- a/ConsolePort/Controller/Securescan.lua
+++ b/ConsolePort/Controller/Securescan.lua
@@ -80,7 +80,8 @@ end
 local ScanGlobal, ScanFrames;
 do	local Scrub, IsProtected, IsForbidden, GetChildren =
 		CPAPI.Scrub, Scan.IsProtected, Scan.IsForbidden, Scan.GetChildren;
-	local SCAN_BUDGET = 500; -- nodes processed per frame
+	local debugprofilestop = debugprofilestop;
+	local SCAN_BUDGET_MS = 1.5; -- max processing time per frame
 
 	-- Classification
 	local function ClassifyNode(collect, node)
@@ -137,7 +138,7 @@ do	local Scrub, IsProtected, IsForbidden, GetChildren =
 	end
 
 	-- Depth-first walk of the UIParent tree, resumable across
-	-- frames when the node budget runs out.
+	-- frames when the time budget runs out.
 	local ScanStack, scanDepth = {}, 0;
 
 	local function PushChildren(...)
@@ -151,26 +152,26 @@ do	local Scrub, IsProtected, IsForbidden, GetChildren =
 	end
 
 	local function SliceGlobalScan(self)
-		local budget = SCAN_BUDGET;
-		while ( scanDepth > 0 and budget > 0 ) do
+		local expires = debugprofilestop() + SCAN_BUDGET_MS;
+		while ( scanDepth > 0 ) do
 			local node = ScanStack[scanDepth];
 			ScanStack[scanDepth] = nil;
 			scanDepth = scanDepth - 1;
-			budget = budget - 1;
 			if not Scrub(IsForbidden(node)) then
 				if Scrub(IsProtected(node)) then
 					ClassifyNode(StageNode, node)
 				end
 				PushChildren(Scrub(GetChildren(node)))
 			end
-		end
-		if ( scanDepth == 0 ) then
-			self:StopGlobalScan()
-			if InCombatLockdown() then
-				self.scanQueued = true;
-			else
-				CommitGlobalScan(self)
+			if ( debugprofilestop() > expires ) then
+				return -- over budget; nodes are never processed partially
 			end
+		end
+		self:StopGlobalScan()
+		if InCombatLockdown() then
+			self.scanQueued = true;
+		else
+			CommitGlobalScan(self)
 		end
 	end
 

--- a/ConsolePort/Controller/Securescan.lua
+++ b/ConsolePort/Controller/Securescan.lua
@@ -137,8 +137,8 @@ do	local Scrub, IsProtected, IsForbidden, GetChildren =
 		self:FireCallbacks(Widgets.Any)
 	end
 
-	-- Depth-first walk of the UIParent tree, resumable across
-	-- frames when the time budget runs out.
+	-- Depth-first walk of the configured container trees,
+	-- resumable across frames when the time budget runs out.
 	local ScanStack, scanDepth = {}, 0;
 
 	local function PushChildren(...)

--- a/ConsolePort/Controller/Securescan.lua
+++ b/ConsolePort/Controller/Securescan.lua
@@ -181,8 +181,18 @@ do	local Scrub, IsProtected, IsForbidden, GetChildren =
 			wipe(staged)
 		end
 		wipe(ScanStack)
-		scanDepth = 1;
-		ScanStack[1] = UIParent;
+		scanDepth = 0;
+		for name in db('scanContainers'):gmatch('[^,%s]+') do
+			local container = _G[name];
+			if C_Widget.IsFrameWidget(container) then
+				scanDepth = scanDepth + 1;
+				ScanStack[scanDepth] = container;
+			end
+		end
+		if ( scanDepth == 0 ) then
+			scanDepth = 1;
+			ScanStack[1] = UIParent;
+		end
 		self:SetScript('OnUpdate', SliceGlobalScan)
 	end
 
@@ -203,6 +213,8 @@ do	local Scrub, IsProtected, IsForbidden, GetChildren =
 		self.scanQueued = nil;
 		self:StartGlobalScan()
 	end, Scan);
+
+	db:RegisterSafeCallback('Settings/scanContainers', function() ScanGlobal() end)
 end
 
 ---------------------------------------------------------------

--- a/ConsolePort/Controller/Securescan.lua
+++ b/ConsolePort/Controller/Securescan.lua
@@ -182,13 +182,15 @@ do	local Scrub, IsProtected, IsForbidden, GetChildren =
 		wipe(ScanStack)
 		scanDepth = 1;
 		ScanStack[1] = UIParent;
-		self.scanActive = true;
 		self:SetScript('OnUpdate', SliceGlobalScan)
 	end
 
 	function Scan:StopGlobalScan()
-		self.scanActive = nil;
 		self:SetScript('OnUpdate', nil)
+	end
+
+	function Scan:IsScanActive()
+		return self:GetScript('OnUpdate') ~= nil;
 	end
 
 	-- Global scan request
@@ -215,7 +217,7 @@ end
 
 function Scan:PLAYER_REGEN_DISABLED()
 	ScanGlobal.Cancel()
-	if self.scanActive then
+	if self:IsScanActive() then
 		self.scanQueued = true;
 		self:StopGlobalScan()
 	end

--- a/ConsolePort/Model/Data/Variables.lua
+++ b/ConsolePort/Model/Data/Variables.lua
@@ -34,6 +34,12 @@ db:Register('Variables', CPAPI.Callable({
 		desc = 'Override class theme for interface styling.';
 		hide = true;
 	};
+	scanContainers = _{String('UIParent');
+		name = 'Frame Scan Containers';
+		desc = 'Comma-separated list of container frames to scan for unit frames and action buttons.';
+		note = 'Container names are resolved from the global environment. Invalid entries are ignored; if no entry resolves, UIParent is used.';
+		advd = true;
+	};
 	--------------------------------------------------------------------------------------------------------
 	_('Crosshair', INTERFACE_LABEL);
 	--------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Replaces EnumerateFrames in the secure scanner with a depth-first walk of configured container trees, after concluding that EnumerateFrames is not a reliable method to gather unit frames, action buttons or action bars.

## Changes

- The scanner walks `GetChildren()` recursively from a set of root containers using an explicit stack, so pausing and resuming across frames no longer depends on engine iteration order.
- Time-sliced on a 1.5 ms budget per frame, checked after each fully processed node: a node's child set is never split, fast machines finish in fewer frames, slow machines just take more.
- Forbidden frames are skipped explicitly, including their subtrees (EnumerateFrames used to filter these for us).
- New advanced setting `scanContainers`: comma-separated list of container names resolved from the global environment, default `UIParent`. Invalid entries are ignored, and if nothing resolves the scanner falls back to UIParent. Changing the setting triggers a rescan.
- Scan activity is derived from the OnUpdate script instead of a separate state field.
- Removed with the rewrite: the seen-set, the discovery funnel hooks, and abort progress preservation. Commits are wipe-and-rebuild again, and rescans handle reclassification.

## Measurements

Profiled in game with ConsolePort_Debug (11,573 nodes, desktop): collecting the whole tree in a single frame costs ~9-10 ms, which is a dropped frame on a desktop and an estimated 20-40 ms hitch on handhelds, so the sliced walk stays. The reused stack allocates +12 KB per pass versus +1.5 MB for a naive recursive collection.

## To verify in game

Unit frames parented outside the configured containers (nil parent, WorldFrame) are invisible to the walk. Test with oUF-family addons and adjust `scanContainers` if needed.