### PR TITLE
Reconcile setting visibility through tree nodes

### DIFF
--- a/ConsolePort_Config/Controller/Setting.lua
+++ b/ConsolePort_Config/Controller/Setting.lua
@@ -41,10 +41,6 @@ local function MountDatapoint(self, dp)
 
 			self:SetDataCallback(callbackFn)
 			self:RegisterCallback(callbackID, self.OnValueChanged)
-
-			if (field.deps) then
-				self:SetDependencies(field.deps)
-			end
 		end
 	end
 end
@@ -78,19 +74,6 @@ function Setting:Reset()
 	self.registry, self.callbacks = nil, nil;
 end
 
-function Setting:SetDependencies(deps)
-	self.deps = CreateFlags(0);
-	local flags, callbacks = {}, {};
-	for dep, value in db.table.spairs(deps) do
-		tinsert(flags, dep)
-		callbacks[dep] = self:RegisterDependency(dep, value)
-	end
-	self.flags = FlagsUtil.MakeFlags(unpack(flags))
-	for dep, callback in pairs(callbacks) do
-		callback(nil, self.registry(dep))
-	end
-end
-
 function Setting:RegisterCallback(callbackID, callback, ...)
 	self.callbacks = self.callbacks or {};
 	self.registry:RegisterCallback(callbackID, callback, self, ...)
@@ -108,21 +91,21 @@ do -- Dependencies
 		['function'] = function (lhs, rhs) return not lhs(rhs) end;
 	}, function() return function(lhs, rhs) return lhs ~= rhs end end)
 
-	local TriggerDependencyChanged = CPAPI.Proxy({}, function(self, registry)
-		return rawset(self, registry, CPAPI.Debounce(
-			registry.TriggerEvent, registry, 'OnDependencyChanged'
-		))[registry];
-	end)
-
-	local function OnDependencyChanged(self, dep, depValue, _, value)
-		self.deps:SetOrClear(self.flags[dep], Comparator[type(depValue)](depValue, value))
-		self.metaData.hide = self.deps:IsAnySet();
-		TriggerDependencyChanged[self.registry](dep)
-	end
-
-	function Setting:RegisterDependency(dep, value)
-		local callbackID = dep:match('/') and dep or Path(self.pathID, dep);
-		local callback = GenerateClosure(OnDependencyChanged, self, dep, value)
-		return self:RegisterCallback(callbackID, callback)
+	---@brief Test if a datapoint should be shown, evaluating its
+	---       dependencies against the current values in its registry.
+	function Setting.IsDatapointShown(dp)
+		local field = dp.field;
+		if field.hide then
+			return false;
+		end
+		if field.deps then
+			local registry = dp.registry or db;
+			for dep, value in pairs(field.deps) do
+				if Comparator[type(value)](value, registry(dep)) then
+					return false;
+				end
+			end
+		end
+		return true;
 	end
 end

--- a/ConsolePort_Config/View/Settings/Panel.lua
+++ b/ConsolePort_Config/View/Settings/Panel.lua
@@ -1,4 +1,4 @@
-local env = CPAPI.GetEnv(...);
+local env, db = CPAPI.GetEnv(...);
 local Settings = env:GetContextPanel();
 local Panel = {}; env.SettingsPanel = Panel;
 
@@ -52,11 +52,82 @@ function Panel:OnSubcatClicked(text, set)
 	self:SetActiveCategory(text, set)
 end
 
-function Panel:OnDependencyChanged(...)
-	local _, right = self:GetLists()
-	RunNextFrame(function()
-		right:GetScrollView():Layout()
-	end)
+do -- Dependency reconciliation
+	local function FindNodeByOrdinal(header, ordinal)
+		for _, node in ipairs(header:GetNodes()) do
+			if ( node:GetData().ordinal == ordinal ) then
+				return node;
+			end
+		end
+	end
+
+	local function FindInsertionIndex(header, ordinal)
+		local nodes = header:GetNodes()
+		for index, node in ipairs(nodes) do
+			local other = node:GetData().ordinal;
+			if ( not other or other > ordinal ) then
+				return index;
+			end
+		end
+		return #nodes + 1;
+	end
+
+	-- Inserts or removes setting nodes when their dependencies
+	-- change, leaving the rest of the tree untouched.
+	function Panel:OnDependencyChanged()
+		local ledger = self.dependencyLedger;
+		if not ledger then return end;
+		local IsDatapointShown = env.Setting.IsDatapointShown;
+		local skipInvalidation, dirty = true, false;
+		for dp, entry in pairs(ledger) do
+			local node = FindNodeByOrdinal(entry.header, entry.ordinal)
+			if IsDatapointShown(dp) then
+				if not node then
+					local index = FindInsertionIndex(entry.header, entry.ordinal)
+					entry.header:InsertNodeAtIndex(dp.type:New(dp), index):GetData().ordinal = entry.ordinal;
+					dirty = true;
+				end
+			elseif node then
+				entry.header:Remove(node, skipInvalidation)
+				dirty = true;
+			end
+		end
+		if dirty then
+			local _, right = self:GetLists()
+			right:GetDataProvider():Invalidate()
+		end
+	end
+end
+
+function Panel:UpdateDependencyWatchers()
+	local watchers = self.dependencyWatchers;
+	if watchers then
+		for _, watcher in ipairs(watchers) do
+			watcher.registry:UnregisterCallback(watcher.event, self)
+		end
+		wipe(watchers)
+	else
+		watchers = {};
+		self.dependencyWatchers = watchers;
+	end
+	if not self.activeData then return end;
+	local seen = {};
+	for _, dp in ipairs(self.activeData) do
+		local deps = dp.field.deps;
+		if deps then
+			local registry = dp.registry or db;
+			local events = seen[registry] or {};
+			seen[registry] = events;
+			for dep in pairs(deps) do
+				local event = dep:match('/') and dep or (dp.pathID or 'Settings')..'/'..dep;
+				if not events[event] then
+					events[event] = true;
+					registry:RegisterCallback(event, self.OnDependencyChanged, self)
+					tinsert(watchers, { registry = registry, event = event })
+				end
+			end
+		end
+	end
 end
 
 function Panel:OnDirty()
@@ -87,6 +158,7 @@ function Panel:RenderSettings()
 	local settings = right:GetDataProvider()
 	settings:Flush()
 	self:Render(settings, self.activeText, self.activeData, true, true)
+	self:UpdateDependencyWatchers()
 
 	return settings;
 end

--- a/ConsolePort_Config/View/Settings/Renderer.lua
+++ b/ConsolePort_Config/View/Settings/Renderer.lua
@@ -127,42 +127,69 @@ function Renderer:Render(provider, title, data, preferCollapsed, useDeviceEdit, 
 		provider:Insert(self.MakeDivider())
 	end
 
+	-- Settings with unmet dependencies are not rendered. Every setting
+	-- is assigned an ordinal within its header and tracked in a ledger,
+	-- so that visibility changes can be reconciled without a re-render.
+	local IsDatapointShown = env.Setting.IsDatapointShown;
+	local ledger, ordinals = not flattened and {} or nil, {};
+
+	local function InsertSetting(header, dp)
+		if ledger then
+			local ordinal = (ordinals[header] or 0) + 1;
+			ordinals[header] = ordinal;
+			ledger[dp] = { header = header, ordinal = ordinal };
+			if IsDatapointShown(dp) then
+				local node = header:Insert(dp.type:New(dp))
+				node:GetData().ordinal = ordinal;
+			end
+		elseif IsDatapointShown(dp) then
+			header:Insert(dp.type:New(dp))
+		end
+	end
+
 	local allowHeadless = not flattened or headless;
 	if allowHeadless and next(before) then
 		for i, dp in ipairs(before) do
-			provider:Insert(dp.type:New(dp))
+			if IsDatapointShown(dp) then
+				provider:Insert(dp.type:New(dp))
+			end
 		end
 		provider:Insert(self.MakeDivider())
 	end
 	if next(base) then
 		for i, dp in ipairs(base) do
-			__(GENERAL, dp, false):Insert(dp.type:New(dp))
+			InsertSetting(__(GENERAL, dp, false), dp)
 		end
 	end
 	if hasDeviceSettings then
 		for i, dp in ipairs(path) do
-			__(SYSTEM, dp, false):Insert(dp.type:New(dp))
+			InsertSetting(__(SYSTEM, dp, false), dp)
 		end
 	end
 	if next(cvar) then
 		for i, dp in ipairs(cvar) do
-			__(SYSTEM, dp, false):Insert(dp.type:New(dp))
+			InsertSetting(__(SYSTEM, dp, false), dp)
 		end
 	end
 	if next(advd) then
 		for i, dp in ipairs(advd) do
-			__(ADVANCED_LABEL, dp, preferCollapsed):Insert(dp.type:New(dp))
+			InsertSetting(__(ADVANCED_LABEL, dp, preferCollapsed), dp)
 		end
 	end
 	if allowHeadless and next(after) then
 		for i, dp in ipairs(after) do
-			provider:Insert(dp.type:New(dp))
+			if IsDatapointShown(dp) then
+				provider:Insert(dp.type:New(dp))
+			end
 		end
 	end
 	if next(xtra) then
 		for i, dp in ipairs(xtra) do
-			__(ADVANCED_LABEL, dp, preferCollapsed):Insert(dp.type:New(dp))
+			InsertSetting(__(ADVANCED_LABEL, dp, preferCollapsed), dp)
 		end
+	end
+	if ledger then
+		self.dependencyLedger = ledger;
 	end
 	for _, header in pairs(activeHeaders) do
 		header:Insert(self.MakeDivider())

--- a/ConsolePort_Config/View/Settings/Settings.lua
+++ b/ConsolePort_Config/View/Settings/Settings.lua
@@ -29,7 +29,6 @@ function Settings:OnLoad()
 	CPAPI.Start(self)
 	self:Reindex()
 	self:SetActiveCategory(GENERAL, self.index[SETTING_GROUP_SYSTEM][GENERAL])
-	db:RegisterCallback('OnDependencyChanged', self.OnDependencyChanged, self)
 	db:RegisterCallback('OnVariablesChanged', self.OnIndexChanged, self)
 	db:RegisterCallback('Settings/useCharacterSettings', self.OnToggleCharacterSettings, self)
 end

--- a/ConsolePort_Config/Widget/Templates/Elements.lua
+++ b/ConsolePort_Config/Widget/Templates/Elements.lua
@@ -269,21 +269,10 @@ function Setting:OnAcquire(new)
 	if new then
 		InitializeSetting(self, env.Setting, Setting)
 	end
-	db:RegisterCallback('OnDependencyChanged', self.OnDependencyChanged, self)
 end
 
 function Setting:OnRelease()
 	self:Reset()
-	db:UnregisterCallback('OnDependencyChanged', self)
-end
-
-function Setting:OnDependencyChanged()
-	if not self.metaData then return end;
-	local isShown = not self.metaData.hide;
-	local newExtent = isShown and self.size.y or 0;
-	self:GetElementData():GetData().extent = newExtent;
-	self:SetHeight(newExtent)
-	self:SetShown(isShown)
 end
 
 function Setting:Data(datapoint)
@@ -322,7 +311,6 @@ function Cvar:OnAcquire(new)
 	if new then
 		InitializeSetting(self, env.Setting, Cvar)
 	end
-	db:RegisterCallback('OnDependencyChanged', self.OnDependencyChanged, self)
 end
 
 function Cvar:Get()
@@ -364,14 +352,12 @@ function Mapper:OnAcquire(new)
 	if new then
 		InitializeSetting(self, env.Setting, Mapper)
 	end
-	db:RegisterCallback('OnDependencyChanged', self.OnDependencyChanged, self)
 	db:RegisterCallback('OnMapperConfigLoaded', self.OnMapperValueChanged, self)
 	db:RegisterCallback('OnMapperDeviceChanged', self.OnMapperValueChanged, self)
 end
 
 function Mapper:OnRelease()
 	self:Reset()
-	db:UnregisterCallback('OnDependencyChanged', self)
 	db:UnregisterCallback('OnMapperConfigLoaded', self)
 	db:UnregisterCallback('OnMapperDeviceChanged', self)
 end


### PR DESCRIPTION
Fixes settings sections disappearing in the config when expanding or collapsing headers (e.g. Settings > Targeting > Targeting: expanding Advanced hid the Advanced section and the last General entry; collapsing General brought Advanced back).

## Root cause

Settings with unmet dependencies were hidden by writing `extent = 0` into live element data. Blizzard's `ScrollBoxListStrideMixin:CalculateDataIndices` treats a zero extent as its out-of-range sentinel (legitimate for grids with stride > 1) and stops extending the visible range at the first zero-extent element, so everything after it stopped rendering. The bug only surfaced when a header was toggled, because tree invalidation rebuilds the view's extent cache; until then, stale non-zero cached extents masked the zeros.

## Changes

- `Setting.IsDatapointShown` evaluates `hide` and `deps` statically against the datapoint's registry, preserving the original comparator semantics (function deps as predicates, literal deps compared, all deps must be met).
- The renderer skips unmet settings entirely, so zero-extent elements never enter the view, and stamps each setting with an ordinal within its header, tracked in a ledger.
- The panel watches each dependency variable directly (an unrendered setting has no mounted frame to watch its own deps). On a change it reconciles the tree: `Remove(node, skipInvalidation)` for newly-unmet settings, `InsertNodeAtIndex` at the ordinal-derived position for newly-met ones, then a single `Invalidate`. No re-render, no widget churn; collapse and scroll state are untouched.
- Removed the extent-zeroing element handler and its registrations (Setting/Cvar/Mapper), the per-frame `SetDependencies` machinery, the `metaData.hide` mutation, and the old `OnDependencyChanged` event plumbing.

Side effect worth noting: dependency hiding now works in the action bar config panel too. Its deps fired on the bar env registry while the old element handler listened on the global db, so hiding never applied there. Watchers register on the datapoint's own registry, which closes the gap.

## Verified in game

- Original repro gone; Advanced expands with all General entries intact.
- Toggling Friend Soft Targeting shows/hides the friendly icon and nameplate settings in their correct positions.
- Search results honor dependency visibility.
- Bar config macro text and XP bar dependencies hide and show correctly.