### PR TITLE
Fix secret value access errors and autocast taint

### DIFF
--- a/ConsolePort/Controller/LED.lua
+++ b/ConsolePort/Controller/LED.lua
@@ -17,13 +17,13 @@ local LED, Modes = CPAPI.CreateEventHandler({'Frame', '$parentLEDHandler', Conso
 local SetLedColor = C_GamePad.SetLedColor or nop;
 local ClearLedColor = C_GamePad.ClearLedColor or nop;
 local GetClassColor = C_ClassColor and C_ClassColor.GetClassColor or GetClassColorObj;
-local UnitClass, select = UnitClass, select;
+local Scrub, UnitClass, select = CPAPI.Scrub, UnitClass, select;
 local BLACK = BLACK_FONT_COLOR or CreateColor(0, 0, 0, 1);
 
 local function GetClassColorObjForUnit(unit)
-	local class = select(2, UnitClass(unit));
+	local class = Scrub(select(2, UnitClass(unit)));
 	if class then
-		return GetClassColor(class);
+		return GetClassColor(class) or BLACK;
 	end
 	return BLACK;
 end

--- a/ConsolePort/Controller/Securescan.lua
+++ b/ConsolePort/Controller/Securescan.lua
@@ -157,7 +157,9 @@ do	local Scrub, IsProtected, IsForbidden, GetChildren =
 			local node = ScanStack[scanDepth];
 			ScanStack[scanDepth] = nil;
 			scanDepth = scanDepth - 1;
-			if not Scrub(IsForbidden(node)) then
+			-- Secret forbidden state scrubs to nil; only an explicit
+			-- false means the node is accessible.
+			if ( Scrub(IsForbidden(node)) == false ) then
 				if Scrub(IsProtected(node)) then
 					ClassifyNode(StageNode, node)
 				end

--- a/ConsolePort/Libs/Local/ActionButton.lua
+++ b/ConsolePort/Libs/Local/ActionButton.lua
@@ -63,6 +63,44 @@ function Pet:UpdateLocal()
 end
 
 ---------------------------------------------------------------
+-- Autocast overlay
+---------------------------------------------------------------
+-- Clients with AutoCastOverlayManagerMixin route ShowAutoCastEnabled
+-- through a global manager, where insecurely registered shines taint
+-- the shared state and spread to the pet action bar and spell book.
+-- A private manager keeps addon overlays out of the shared one.
+do	local OverlayManager;
+	local function GetOverlayManager()
+		if ( OverlayManager == nil ) then
+			OverlayManager = AutoCastOverlayManagerMixin
+				and Mixin(CreateFrame('Frame'), AutoCastOverlayManagerMixin) or false;
+			if OverlayManager then
+				OverlayManager:OnLoad()
+				OverlayManager:SetScript('OnUpdate', OverlayManager.OnUpdate)
+			end
+		end
+		return OverlayManager or nil;
+	end
+
+	function Lib.ShowAutoCastEnabled(overlay, isEnabled)
+		local manager = GetOverlayManager()
+		if not manager then
+			return overlay:ShowAutoCastEnabled(isEnabled)
+		end
+		if isEnabled then
+			manager:AddActiveShine(overlay)
+		else
+			manager:RemoveActiveShine(overlay)
+		end
+		if overlay.sparkles then
+			for _, sparkle in ipairs(overlay.sparkles) do
+				sparkle:SetShown(isEnabled)
+			end
+		end
+	end
+end
+
+---------------------------------------------------------------
 Lib.Skin, Lib.SkinUtility = {}, {};
 ---------------------------------------------------------------
 

--- a/ConsolePort/Model/Game/Actionbar.lua
+++ b/ConsolePort/Model/Game/Actionbar.lua
@@ -146,7 +146,7 @@ do
 	end
 
 	function FindActionButtons(callback, cache, this)
-		if not IsFrameWidget(this) or Frame.IsForbidden(this) or IGNORE_FRAMES[this] then return cache end
+		if not IsFrameWidget(this) or Scrub(Frame.IsForbidden(this)) ~= false or IGNORE_FRAMES[this] then return cache end
 		-------------------------------------
 		local action = ValidateActionID(this)
 		if IsActionButton(this, action) and callback(cache, this, action) then

--- a/ConsolePort/Utils/Wrapper.lua
+++ b/ConsolePort/Utils/Wrapper.lua
@@ -645,22 +645,25 @@ function CPAPI.SetModelLight(self, enabled, lightValues)
 	))
 end
 
-function CPAPI.AutoCastStart(self, autoCastAllowed, ...)
-	if (self.Shine or self.AutoCastShine) and AutoCastShine_AutoCastStart then
-		return AutoCastShine_AutoCastStart(self.Shine or self.AutoCastShine, ...)
-	end
-	if self.AutoCastOverlay and self.AutoCastOverlay.ShowAutoCastEnabled then
-		self.AutoCastOverlay:SetShown(autoCastAllowed)
-		return self.AutoCastOverlay:ShowAutoCastEnabled(true)
-	end
-end
+do	local Lib = LibStub('ConsolePortActionButton');
 
-function CPAPI.AutoCastStop(self, autoCastAllowed)
-	if (self.Shine or self.AutoCastShine) and AutoCastShine_AutoCastStop then
-		return AutoCastShine_AutoCastStop(self.Shine or self.AutoCastShine)
+	function CPAPI.AutoCastStart(self, autoCastAllowed, ...)
+		if (self.Shine or self.AutoCastShine) and AutoCastShine_AutoCastStart then
+			return AutoCastShine_AutoCastStart(self.Shine or self.AutoCastShine, ...)
+		end
+		if self.AutoCastOverlay and self.AutoCastOverlay.ShowAutoCastEnabled then
+			self.AutoCastOverlay:SetShown(autoCastAllowed)
+			return Lib.ShowAutoCastEnabled(self.AutoCastOverlay, true)
+		end
 	end
-	if self.AutoCastOverlay and self.AutoCastOverlay.ShowAutoCastEnabled then
-		self.AutoCastOverlay:SetShown(autoCastAllowed)
-		return self.AutoCastOverlay:ShowAutoCastEnabled(false)
+
+	function CPAPI.AutoCastStop(self, autoCastAllowed)
+		if (self.Shine or self.AutoCastShine) and AutoCastShine_AutoCastStop then
+			return AutoCastShine_AutoCastStop(self.Shine or self.AutoCastShine)
+		end
+		if self.AutoCastOverlay and self.AutoCastOverlay.ShowAutoCastEnabled then
+			self.AutoCastOverlay:SetShown(autoCastAllowed)
+			return Lib.ShowAutoCastEnabled(self.AutoCastOverlay, false)
+		end
 	end
 end


### PR DESCRIPTION
Four fixes for the error reports coming out of 12.1 and Mists 5.5.4, all variations of secret values and shared state not being accounted for.

## Secure scan: secret forbidden state (1034x report)

The recursive walk guarded nodes with `not Scrub(IsForbidden(node))`. On 12.1's aura container buttons (created from secured code in Blizzard_AuraContainer), `IsForbidden` answers with a secret; `Scrub` turns that into nil, `not nil` passes the guard, and the following `IsProtected` call throws "attempt to access forbidden object". The guard now only accepts an explicit `false` as accessible, so secret-gated frames and their subtrees are skipped. If the error count does not drop to zero, `IsForbidden` genuinely returns false on these frames and the fallback is a pcall probe — flagging in advance.

## Action bar scan: same trap (25x report)

`FindActionButtons` used a raw, unscrubbed `Frame.IsForbidden(this)` in its guard and hit the same aura buttons through the UIParent walk. Now scrubbed with the same explicit-false test.

## LED handler: secret unit class (357x report)

`UnitClass('target')` returns a secret class token for hostile players in 12.x, which poisoned the color object handed to `C_GamePad.SetLedColor`. The class is scrubbed at the source with a black fallback, also covering `GetClassColor` returning nothing. Explains the correlation with PvP tab-targeting addons: they just target enemy players a lot.

## Pet autocast: shared overlay manager taint

On clients with `AutoCastOverlayManagerMixin` (Mists 5.5.4), `AutoCastOverlay:ShowAutoCastEnabled` registers the overlay with the global `AutoCastOverlayManager` singleton. Insecurely registered shines taint its shared `activeShines` table, and the taint spreads to the pet action bar and spell book paths that use the same manager — the long-suspected "pet bar taints the UI" mechanism. Fixed the same way as Bartender4 (f2bf0dfe): a private manager built from the same mixin, created lazily on first use. `CPAPI.AutoCastStart/Stop` now route through `Lib.ShowAutoCastEnabled` in the local ActionButton lib, which registers with the private manager and toggles the sparkles itself; clients without the manager keep the plain self-contained mixin behavior.