### PR TITLE
Handle forbidden aspects and shared dispatcher taint

### DIFF
--- a/ConsolePort/Controller/Securescan.lua
+++ b/ConsolePort/Controller/Securescan.lua
@@ -78,8 +78,8 @@ end
 -- Global scanning
 ---------------------------------------------------------------
 local ScanGlobal, ScanFrames;
-do	local Scrub, IsProtected, IsForbidden, GetChildren =
-		CPAPI.Scrub, Scan.IsProtected, Scan.IsForbidden, Scan.GetChildren;
+do	local Scrub, IsProtected, IsRestricted, GetChildren =
+		CPAPI.Scrub, Scan.IsProtected, CPAPI.IsObjectRestricted, Scan.GetChildren;
 	local debugprofilestop = debugprofilestop;
 	local SCAN_BUDGET_MS = 1.5; -- max processing time per frame
 
@@ -157,9 +157,7 @@ do	local Scrub, IsProtected, IsForbidden, GetChildren =
 			local node = ScanStack[scanDepth];
 			ScanStack[scanDepth] = nil;
 			scanDepth = scanDepth - 1;
-			-- Secret forbidden state scrubs to nil; only an explicit
-			-- false means the node is accessible.
-			if ( Scrub(IsForbidden(node)) == false ) then
+			if not IsRestricted(node) then
 				if Scrub(IsProtected(node)) then
 					ClassifyNode(StageNode, node)
 				end

--- a/ConsolePort/Model/Game/Actionbar.lua
+++ b/ConsolePort/Model/Game/Actionbar.lua
@@ -105,6 +105,7 @@ do
 	local VALID_BUTTON_TYPE = ActionBarAPI.Lookup.Types;
 	local IGNORE_FRAMES     = ActionBarAPI.Lookup.Ignore;
 	local IsFrameWidget     = C_Widget.IsFrameWidget;
+	local IsRestricted      = CPAPI.IsObjectRestricted;
 	local Frame             = GetFrameMetatable().__index;
 	local Scrub             = CPAPI.Scrub;
 
@@ -146,7 +147,7 @@ do
 	end
 
 	function FindActionButtons(callback, cache, this)
-		if not IsFrameWidget(this) or Scrub(Frame.IsForbidden(this)) ~= false or IGNORE_FRAMES[this] then return cache end
+		if not IsFrameWidget(this) or IsRestricted(this) or IGNORE_FRAMES[this] then return cache end
 		-------------------------------------
 		local action = ValidateActionID(this)
 		if IsActionButton(this, action) and callback(cache, this, action) then

--- a/ConsolePort/Utils/Wrapper.lua
+++ b/ConsolePort/Utils/Wrapper.lua
@@ -376,6 +376,27 @@ CPAPI.IsXPUserDisabled               = IsXPUserDisabled   or nop;
 CPAPI.PlayerHasToy                   = PlayerHasToy       or nop;
 CPAPI.Scrub                          = scrubsecretvalues  or function(...)return...end;
 
+do -- Object accessibility
+	local Widget = GetFrameMetatable().__index;
+	local Scrub, IsForbidden, HasAccessConstraints, HasAnyForbiddenAspects =
+		CPAPI.Scrub, Widget.IsForbidden, Widget.HasAccessConstraints, Widget.HasAnyForbiddenAspects;
+
+	-- Restricted objects may pass an IsForbidden check, but have forbidden
+	-- aspects that disallow the use of certain APIs. Accessibility queries
+	-- return secrets for objects carrying the ObjectSecurity aspect, which
+	-- scrub to nil; only an explicit false means the object is accessible.
+	if ( HasAccessConstraints and HasAnyForbiddenAspects ) then
+		function CPAPI.IsObjectRestricted(object)
+			return Scrub(HasAccessConstraints(object)) ~= false
+				or Scrub(HasAnyForbiddenAspects(object)) ~= false;
+		end
+	else
+		function CPAPI.IsObjectRestricted(object)
+			return Scrub(IsForbidden(object)) ~= false;
+		end
+	end
+end
+
 -- Complex wrappers
 CPAPI.GetContainerItemInfo = function(...)
 	if C_Container and C_Container.GetContainerItemInfo then

--- a/ConsolePort_Bar/Controller/Blizzard/Retail.lua
+++ b/ConsolePort_Bar/Controller/Blizzard/Retail.lua
@@ -29,6 +29,16 @@ local function hideActionButton(button)
 	button:Hide()
 	button:UnregisterAllEvents()
 	button:SetAttributeNoHandler('statehidden', true)
+	-- Shared dispatchers invoke buttons regardless of their own event
+	-- registrations, spreading hidden button taint to the dispatch loop.
+	-- Removal from the keyed dispatchers is taint-safe; the array-backed
+	-- ActionBarButtonEventsFrame is not, so slot changes still get through.
+	if ActionBarActionEventsFrame then
+		ActionBarActionEventsFrame:UnregisterFrame(button)
+	end
+	if ActionBarButtonUpdateFrame then
+		ActionBarButtonUpdateFrame:UnregisterFrame(button)
+	end
 end
 
 local function NPE_LoadUI()
@@ -94,6 +104,9 @@ function env.UIHandler:HideBlizzard()
 		OverrideActionBar        = true;
 	}) do
 		hideEditModeFrame(_G[frame], clearEvents)
+	end
+	for i = 1, NUM_OVERRIDE_BUTTONS or 6 do
+		hideActionButton(_G['OverrideActionBarButton' .. i])
 	end
 
 	---------------------------------------------------------------


### PR DESCRIPTION
Fixes the remaining 12.1 error classes: the scan errors on aura container buttons, and the action bar taint errors on hidden Blizzard buttons. Verified in game with a full battleground producing zero errors and a taint log with no blocked actions and no ConsolePort entries beyond benign execution transitions.

## Forbidden aspects in the frame scans

Aura container buttons pass an `IsForbidden` check but carry Forbidden Aspects (12.1 Private Script Objects), so individual APIs like `IsProtected` throw "attempt to access forbidden object" anyway. Both the secure scan and the action bar scan now guard with `CPAPI.IsObjectRestricted`, mirroring Blizzard's own accessibility predicate from the restricted environment:

```lua
HasAccessConstraints(object) or HasAnyForbiddenAspects(object)
```

`HasAccessConstraints` subsumes classic forbidden state per its documentation, and both queries return secrets for objects with the ObjectSecurity aspect, so only an explicit false counts as accessible. Clients without these APIs fall back to the previous `IsForbidden` check. Type detection (`IsObjectType('AuraContainer')`) was rejected: type answers are themselves secret under the ObjectType aspect.

## Shared dispatcher taint on hidden buttons

Blizzard action buttons receive events through shared dispatcher frames (`ActionBarButtonEventsFrame`, `ActionBarActionEventsFrame`, `ActionBarButtonUpdateFrame`) via method calls, regardless of the buttons' own event registrations - so hidden buttons kept processing cooldown and slot events under our taint, producing blocked `SetAttribute` calls in `UpdatePingAttributes` and "secret values are only allowed during untainted execution" errors in `SetCooldown`. Once one hidden button taints a dispatch pass, the taint persists for the remainder of the loop and reaches buttons we never touched (verified against the Elune reference implementation of the taint model).

- `hideActionButton` now removes hidden buttons from the two keyed dispatchers via their official `UnregisterFrame` APIs. Keyed removal is taint-safe: secure iteration skips niled nodes without reading their taint (also verified in Elune). The array-backed `ActionBarButtonEventsFrame` has no safe removal - shifting the array would rewrite surviving entries under taint - so slot change events can still reach hidden buttons; this residual matches Bartender4's exposure.
- `OverrideActionBarButton1-6` are now disarmed like the other bars; they previously kept all their registrations while their bar was hidden (#182).

Bartender4 hit the identical `SetCooldown` error (their #275/#276); their fix covered LibActionButton's own buttons via the new duration object APIs, while the hidden Blizzard button dispatch was left as is - the dispatcher unregistration here is new ground.