### PR TITLE
Fix secret class token and popup edit box errors

### DIFF
--- a/ConsolePort/View/Cursors/Raid.lua
+++ b/ConsolePort/View/Cursors/Raid.lua
@@ -444,7 +444,7 @@ do 	local IsSpellHarmful, IsSpellHelpful = CPAPI.IsSpellHarmful, CPAPI.IsSpellHe
 		self.unit = unit;
 		if UnitExists(unit) then
 			self:UpdateHealthForUnit(unit)
-			self:UpdateColor(GetClassColorObj(select(2, UnitClass(unit))))
+			self:UpdateColor(GetClassColorObj(CPAPI.Scrub(select(2, UnitClass(unit)))))
 		end
 		self.UnitPortrait:SetPortrait(unit)
 		if unit then

--- a/ConsolePort_Config/View/Settings/Elements.lua
+++ b/ConsolePort_Config/View/Settings/Elements.lua
@@ -603,7 +603,8 @@ function BindingPreset:Edit()
 		button3 = DELETE;
 		hasEditBox = 1;
 		OnShow = function(self, data)
-			self.editBox:SetText(data.key)
+			local editBox = self.editBox or self:GetEditBox();
+			editBox:SetText(data.key)
 		end;
 		OnAccept = function(popup, data)
 			local editBox = popup.editBox or popup:GetEditBox();


### PR DESCRIPTION
Two small 12.1 compatibility fixes:

- Raid cursor: scrub the class token from UnitClass before indexing RAID_CLASS_COLORS — secret tokens now fall back to the grey health bar instead of throwing.
- Preset edit popup: use the edit box getter idiom (`popup.editBox or popup:GetEditBox()`) in OnShow, matching the rest of the config addon after the GameDialog rework.