### PR TITLE
Avoid tainting hidden Blizzard action buttons

### DIFF
--- a/ConsolePort/Model/Game/Actionbar.lua
+++ b/ConsolePort/Model/Game/Actionbar.lua
@@ -43,6 +43,7 @@ local ActionBarAPI, _, db = {
 	Lookup = {
 		Buttons = {};
 		Ignore  = {};
+		Native  = {};
 		Stances = {};
 		Types   = {
 			Button = true;
@@ -81,17 +82,14 @@ CPAPI.Proxy(ActionBarAPI.Widget, function(self, id)
 	return _G[ActionBarAPI:GetMappedValue(id, self)]
 end)
 
--- Give default UI action buttons their correct action IDs.
--- This is to make it easier to distinguish action buttons,
--- since action bar addons use this attribute to perform actions.
--- Blizzard's own system does not use the attribute by default,
--- instead resorting to table keys/:GetID() to determine correct action.
--- Assigning the attribute manually unifies default UI with addons.
+-- Cache default UI action IDs without writing attributes to Blizzard-owned
+-- buttons. On modern clients, an addon value in the secure `action` attribute
+-- can taint the stock button's later UpdateAction/UpdateShownButtons path.
 for i=CPAPI.ExtraActionButtonID, 1, -1 do
 	local button = ActionBarAPI.Widget[i]
 	if button then
 		ActionBarAPI.Binding[ActionBarAPI.Action[i]] = i
-		button:SetAttributeNoHandler('action', i)
+		ActionBarAPI.Lookup.Native[button] = i
 	end
 end
 
@@ -104,6 +102,7 @@ end
 do
 	local VALID_BUTTON_TYPE = ActionBarAPI.Lookup.Types;
 	local IGNORE_FRAMES     = ActionBarAPI.Lookup.Ignore;
+	local NATIVE_BUTTONS    = ActionBarAPI.Lookup.Native;
 	local IsFrameWidget     = C_Widget.IsFrameWidget;
 	local IsRestricted      = CPAPI.IsObjectRestricted;
 	local Frame             = GetFrameMetatable().__index;
@@ -118,7 +117,7 @@ do
 	local function ValidateActionID(this)
 		if not Scrub(Frame.IsProtected(this)) then return end
 		if not VALID_BUTTON_TYPE[Scrub(Frame.GetObjectType(this))] then return end
-		return Scrub(Frame.GetAttribute(this, 'action'))
+		return NATIVE_BUTTONS[this] or Scrub(Frame.GetAttribute(this, 'action'))
 	end
 
 	local function IsActionButton(this, action)

--- a/ConsolePort_Bar/Controller/Blizzard/Retail.lua
+++ b/ConsolePort_Bar/Controller/Blizzard/Retail.lua
@@ -2,43 +2,24 @@
 if not CPAPI.IsRetailVersion then return end;
 local _, env = ...;
 
-local function hideEditModeFrame(frame, clearEvents)
+local function hideEditModeFrame(frame)
 	if frame then
-		if clearEvents then
-			frame:UnregisterAllEvents()
-		end
-
-		-- remove some EditMode hooks
-		if frame.system then
-			-- purge the show state to avoid any taint concerns
-			CPAPI.Purge(frame, 'isShownExternal')
-		end
-
-		-- EditMode overrides the Hide function, avoid calling it as it can taint
-		if frame.HideBase then
-			frame:HideBase()
-		else
-			frame:Hide()
-		end
-		frame:SetParent(env.UIHandler)
+		-- Do not Hide, reparent, unregister, or mutate Edit Mode state on
+		-- Blizzard-owned bars. Those operations invoke Blizzard lifecycle code
+		-- from an addon-tainted stack and can poison action-button fields that
+		-- are later consumed with secret cooldown values in combat.
+		frame:SetAlpha(0)
+		frame:EnableMouse(false)
 	end
 end
 
 local function hideActionButton(button)
 	if not button then return end
-	button:Hide()
-	button:UnregisterAllEvents()
-	button:SetAttributeNoHandler('statehidden', true)
-	-- Shared dispatchers invoke buttons regardless of their own event
-	-- registrations, spreading hidden button taint to the dispatch loop.
-	-- Removal from the keyed dispatchers is taint-safe; the array-backed
-	-- ActionBarButtonEventsFrame is not, so slot changes still get through.
-	if ActionBarActionEventsFrame then
-		ActionBarActionEventsFrame:UnregisterFrame(button)
-	end
-	if ActionBarButtonUpdateFrame then
-		ActionBarButtonUpdateFrame:UnregisterFrame(button)
-	end
+	-- Keep the stock button fully owned and updated by Blizzard. In
+	-- particular, do not set statehidden or remove it from shared dispatchers:
+	-- both approaches leave Blizzard iterating tainted button state.
+	button:SetAlpha(0)
+	button:EnableMouse(false)
 end
 
 local function NPE_LoadUI()
@@ -63,19 +44,9 @@ function env.UIHandler:HideBlizzard()
 	for i = 1, 12 do
 		hideActionButton(_G['ActionButton' .. i])
 	end
-	-- these events drive visibility, we want the MainActionBar to remain invisible
-	for _, event in ipairs({
-		'PLAYER_REGEN_ENABLED';
-		'PLAYER_REGEN_DISABLED';
-		'ACTIONBAR_SHOWGRID';
-		'ACTIONBAR_HIDEGRID';
-	}) do
-		MainActionBar:UnregisterEvent(event)
-	end
-
 	---------------------------------------------------------------
 	-- Action bars
-	for bar, clearEvents in pairs({
+	for bar in pairs({
 		MultiBarBottomLeft  = true;
 		MultiBarBottomRight = true;
 	--	MultiBarLeft        = true;
@@ -84,7 +55,7 @@ function env.UIHandler:HideBlizzard()
 	--	MultiBar6           = true;
 	--	MultiBar7           = true;
 	}) do
-		hideEditModeFrame(_G[bar], clearEvents)
+		hideEditModeFrame(_G[bar])
 		for i = 1, 12 do -- Hide MultiBar Buttons
 			hideActionButton(_G[bar .. 'Button' .. i])
 		end
@@ -92,7 +63,7 @@ function env.UIHandler:HideBlizzard()
 
 	---------------------------------------------------------------
 	-- HUD frames
-	for frame, clearEvents in pairs({
+	for frame in pairs({
 	--	BagsBar                  = true;
 	--	MicroButtonAndBagsBar    = false;
 	--	MicroMenu                = true;
@@ -103,10 +74,16 @@ function env.UIHandler:HideBlizzard()
 		StatusTrackingBarManager = false;
 		OverrideActionBar        = true;
 	}) do
-		hideEditModeFrame(_G[frame], clearEvents)
+		hideEditModeFrame(_G[frame])
 	end
 	for i = 1, NUM_OVERRIDE_BUTTONS or 6 do
 		hideActionButton(_G['OverrideActionBarButton' .. i])
+	end
+	for i = 1, NUM_PET_ACTION_SLOTS or 10 do
+		hideActionButton(_G['PetActionButton' .. i])
+	end
+	for i = 1, NUM_POSSESS_SLOTS or 2 do
+		hideActionButton(_G['PossessButton' .. i])
 	end
 
 	---------------------------------------------------------------


### PR DESCRIPTION
## Summary

This is a follow-up to #204 for the remaining action-bar taint reported in #182.

On Retail 12.1.0 (Interface 120100) with ConsolePort 3.2.2, the hidden Blizzard buttons could still receive action-bar events after ConsolePort had hidden/reparented them and written their secure `action` attributes. That produced protected `SetAttribute` and `SetShown` failures, followed by secret-value errors in `Cooldown:SetCooldown`. The traces included both the array-backed event path around `ActionButton.lua:223` and the keyed dispatcher path around `ActionButton.lua:333`.

## Changes

- Leave Blizzard-owned action buttons registered and under Blizzard lifecycle control.
- Conceal the stock bars with alpha and disabled mouse input instead of hiding, reparenting, clearing events, or setting protected visibility state.
- Keep the action ID used by ConsolePort hotkey lookup in an addon-owned weak-key table instead of writing it to each Blizzard button secure `action` attribute.

This retains the unregister cleanup added by #204 where applicable, while removing the remaining taint boundary for residual dispatcher events.

## Verification

- Both changed files parse successfully with `luaparse`.
- `git diff --check` passes.
- In-game verification on the previously affected setup produced no further Lua/action-bar blocked errors.

The tradeoff is that visually concealed stock Blizzard buttons continue receiving their normal updates, but this avoids ConsolePort taking ownership of their protected lifecycle.

Fixes #182