### PR TITLE
Fix unit pool watching party units in raids

### DIFF
--- a/ConsolePort_Target/Database.lua
+++ b/ConsolePort_Target/Database.lua
@@ -15,7 +15,7 @@ env.Variables = {
 		note = 'Automatically disabled if an inactive component is clicked from a macro.';
 		advd = true;
 	};
-	unitHotkeyTokens = _{Data.String('[group:party] party1-4, player, party1-4pet, boss1-8, arena1-5 [group:raid] raid1-40, boss1-8 [] player');
+	unitHotkeyTokens = _{Data.String('[group:raid] raid1-40, boss1-8 [group:party] party1-4, player, party1-4pet, boss1-8, arena1-5 [] player');
 		name = 'Unit Pool';
 		desc = 'Units to watch, as lists of unit tokens selected by macro conditions. Use [] for the unconditional fallback.';
 		note = 'E.g. '..BLUE('[group:party] party1-4, player [] player')..' watches your party while grouped, otherwise only yourself.';


### PR DESCRIPTION
Unit hotkeys did not display on raid frames, while targeting through them still worked. Reported by several users, raids only.

`[group:party]` is true while in a raid, and the pool driver concatenates clauses in the order written, so `SecureCmdOptionParse` took the first match and the `[group:raid]` clause was unreachable. A raid therefore watched `party1-4`/`player` — the player's own subgroup. Those tokens target correctly, since the secure side only deals in unit tokens, which is why blind combos worked. The scan cache keys frames by the token Blizzard's raid frames carry (`CompactRaidGroup1Member1 -> raid2`), so the assignment lookup missed on every frame and no hotkey was drawn. 5-man content was unaffected because there the party clause is also the correct one.

The raid clause is now evaluated first. Untouched settings pick up the new default; a customised pool is left alone. The target ring shares the pool and was likewise limited to the player's subgroup in raids.