### PR TITLE
Bugfixes: World autocast shine, binding preset indices

### DIFF
--- a/ConsolePort_World/Controller/Pet.lua
+++ b/ConsolePort_World/Controller/Pet.lua
@@ -139,9 +139,10 @@ function PetAction:Update()
 
 	self:SetChecked(isActive and true or false)
 
-	if self.AutoCastOverlay then
-		self.AutoCastOverlay:SetShown(autoCastAllowed)
-		self.AutoCastOverlay:ShowAutoCastEnabled(autoCastEnabled)
+	if autoCastEnabled then
+		CPAPI.AutoCastStart(self, autoCastAllowed)
+	else
+		CPAPI.AutoCastStop(self, autoCastAllowed)
 	end
 
 	self:UpdateCooldown()


### PR DESCRIPTION
**Route World pet autocast through CPAPI.** On Classic, `AutoCastOverlayMixin:ShowAutoCastEnabled` registers the overlay in the shared `AutoCastOverlayManager` shine list. The quick menu pet row called it directly, so its overlay landed in that list as a tainted value; Blizzard's `UpdateFlash` → `RemoveActiveShine` → `tDeleteItem` then read it and tainted the action button dispatch pass (the `ConsolePort_World` blame in #182). Route it through `CPAPI.AutoCastStart/Stop`, which use the private overlay manager added in 91f93d66, same as the pet ring. No change on Retail, where the overlay is self-contained.

**Look up binding presets by key instead of stale index.** Preset datapoints stored their position in the settings list at build time. `Delete` removed from the list without reindexing and `Rename` wrote into `store[index]`, so after the first delete in a session every later preset pointed one slot off: a second delete hid the wrong preset from the list, and a rename after a delete relabeled the next preset with the renamed key, after which deleting that entry removed the renamed preset's saved bindings. Find the datapoint by key (skipping the read-only device presets, which can share a name with a user preset) and drop the stored index.