### PR TITLE
Bugfixes: binding preset indices, Blizzard bar hider hardening

### DIFF
--- a/ConsolePort/Utils/Utils.lua
+++ b/ConsolePort/Utils/Utils.lua
@@ -263,13 +263,17 @@ do local function ModifyMetatable(owner, key, value)
 	end
 end
 
-function CPAPI.Purge(t, k)
-	t[k] = nil;
-	local c = 42;
-	repeat -- credit: foxlit
-		if t[c] == nil then t[c] = nil end;
-		c = c + 1;
-	until issecurevariable(t, k)
+do local PROBE = '__purge';
+	function CPAPI.Purge(t, k)
+		t[k] = nil;
+		local probe = type(k) == 'string' and k or PROBE;
+		if ( probe ~= k ) then t[probe] = nil end;
+		local c = 42;
+		repeat -- credit: foxlit
+			if t[c] == nil then t[c] = nil end;
+			c = c + 1;
+		until issecurevariable(t, probe)
+	end
 end
 
 ---------------------------------------------------------------

--- a/ConsolePort_Bar/Controller/Blizzard/Blizzard.xml
+++ b/ConsolePort_Bar/Controller/Blizzard/Blizzard.xml
@@ -1,5 +1,4 @@
 <Ui>
-	<Script file="Retail.lua"/>
-	<Script file="Classic.lua"/>
+	<Script file="[Family].lua"/>
 	<Script file="GridLayoutUtil.lua"/>
 </Ui>

--- a/ConsolePort_Bar/Controller/Blizzard/Classic.lua
+++ b/ConsolePort_Bar/Controller/Blizzard/Classic.lua
@@ -3,7 +3,6 @@ if CPAPI.IsRetailVersion then return end;
 local _, env = ...;
 local Frame = GetFrameMetatable().__index;
 local Purge = CPAPI.Purge;
-local SetAttributeNoHandler = Frame.SetAttributeNoHandler or Frame.SetAttribute;
 
 local function purgeFromDispatchers(button)
 	if ActionBarActionEventsFrame then
@@ -28,7 +27,7 @@ local function hideActionButton(button)
 	if not button then return end;
 	Frame.Hide(button)
 	Frame.UnregisterAllEvents(button)
-	SetAttributeNoHandler(button, 'statehidden', true)
+	Frame.SetAttributeNoHandler(button, 'statehidden', true)
 	purgeFromDispatchers(button)
 end
 

--- a/ConsolePort_Bar/Controller/Blizzard/Classic.lua
+++ b/ConsolePort_Bar/Controller/Blizzard/Classic.lua
@@ -1,34 +1,35 @@
 -- Credit: https://github.com/Nevcairiel/Bartender4/blob/master/HideBlizzard.lua
 if CPAPI.IsRetailVersion then return end;
 local _, env = ...;
+local Frame = GetFrameMetatable().__index;
+local Purge = CPAPI.Purge;
+local SetAttributeNoHandler = Frame.SetAttributeNoHandler or Frame.SetAttribute;
 
-local function hideEditModeFrame(frame, clearEvents)
-	if frame then
-		if clearEvents then
-			frame:UnregisterAllEvents()
-		end
-
-		-- remove some EditMode hooks
-		if frame.system then
-			-- purge the show state to avoid any taint concerns
-			CPAPI.Purge(frame, 'isShownExternal')
-		end
-
-		-- EditMode overrides the Hide function, avoid calling it as it can taint
-		if frame.HideBase then
-			frame:HideBase()
-		else
-			frame:Hide()
-		end
-		frame:SetParent(env.UIHandler)
+local function purgeFromDispatchers(button)
+	if ActionBarActionEventsFrame then
+		Purge(ActionBarActionEventsFrame.frames, button)
+	end
+	if ActionBarButtonUpdateFrame then
+		Purge(ActionBarButtonUpdateFrame.frames, button)
 	end
 end
 
+local function hideEditModeFrame(frame, clearEvents)
+	if not frame then return end;
+	if clearEvents then
+		Frame.UnregisterAllEvents(frame)
+	end
+	Purge(frame, 'isShownExternal')
+	Frame.Hide(frame)
+	Frame.SetParent(frame, env.UIHandler)
+end
+
 local function hideActionButton(button)
-	if not button then return end
-	button:Hide()
-	button:UnregisterAllEvents()
-	button:SetAttribute('statehidden', true)
+	if not button then return end;
+	Frame.Hide(button)
+	Frame.UnregisterAllEvents(button)
+	SetAttributeNoHandler(button, 'statehidden', true)
+	purgeFromDispatchers(button)
 end
 
 local function NPE_LoadUI()
@@ -60,7 +61,7 @@ function env.UIHandler:HideBlizzard()
 		'ACTIONBAR_SHOWGRID';
 		'ACTIONBAR_HIDEGRID';
 	}) do
-		MainActionBar:UnregisterEvent(event)
+		Frame.UnregisterEvent(MainActionBar, event)
 	end
 
 	---------------------------------------------------------------
@@ -96,6 +97,15 @@ function env.UIHandler:HideBlizzard()
 		OverrideActionBar        = true;
 	}) do
 		hideEditModeFrame(_G[frame], clearEvents)
+	end
+	for i = 1, NUM_OVERRIDE_BUTTONS or 6 do
+		hideActionButton(_G['OverrideActionBarButton' .. i])
+	end
+	for i = 1, NUM_PET_ACTION_SLOTS or 10 do
+		hideActionButton(_G['PetActionButton' .. i])
+	end
+	for i = 1, NUM_POSSESS_SLOTS or 2 do
+		hideActionButton(_G['PossessButton' .. i])
 	end
 
 	---------------------------------------------------------------

--- a/ConsolePort_Bar/Controller/Blizzard/Classic.lua
+++ b/ConsolePort_Bar/Controller/Blizzard/Classic.lua
@@ -1,5 +1,4 @@
 -- Credit: https://github.com/Nevcairiel/Bartender4/blob/master/HideBlizzard.lua
-if CPAPI.IsRetailVersion then return end;
 local _, env = ...;
 local Frame = GetFrameMetatable().__index;
 local Purge = CPAPI.Purge;

--- a/ConsolePort_Bar/Controller/Blizzard/Mainline.lua
+++ b/ConsolePort_Bar/Controller/Blizzard/Mainline.lua
@@ -1,5 +1,4 @@
 -- Credit: https://github.com/Nevcairiel/Bartender4/blob/master/HideBlizzard.lua
-if not CPAPI.IsRetailVersion then return end;
 local _, env = ...;
 local Frame = GetFrameMetatable().__index;
 local Purge = CPAPI.Purge;

--- a/ConsolePort_Bar/Controller/Blizzard/Retail.lua
+++ b/ConsolePort_Bar/Controller/Blizzard/Retail.lua
@@ -1,44 +1,34 @@
 -- Credit: https://github.com/Nevcairiel/Bartender4/blob/master/HideBlizzard.lua
 if not CPAPI.IsRetailVersion then return end;
 local _, env = ...;
+local Frame = GetFrameMetatable().__index;
+local Purge = CPAPI.Purge;
 
-local function hideEditModeFrame(frame, clearEvents)
-	if frame then
-		if clearEvents then
-			frame:UnregisterAllEvents()
-		end
-
-		-- remove some EditMode hooks
-		if frame.system then
-			-- purge the show state to avoid any taint concerns
-			CPAPI.Purge(frame, 'isShownExternal')
-		end
-
-		-- EditMode overrides the Hide function, avoid calling it as it can taint
-		if frame.HideBase then
-			frame:HideBase()
-		else
-			frame:Hide()
-		end
-		frame:SetParent(env.UIHandler)
+local function purgeFromDispatchers(button)
+	if ActionBarActionEventsFrame then
+		Purge(ActionBarActionEventsFrame.frames, button)
+	end
+	if ActionBarButtonUpdateFrame then
+		Purge(ActionBarButtonUpdateFrame.frames, button)
 	end
 end
 
+local function hideEditModeFrame(frame, clearEvents)
+	if not frame then return end;
+	if clearEvents then
+		Frame.UnregisterAllEvents(frame)
+	end
+	Purge(frame, 'isShownExternal')
+	Frame.Hide(frame)
+	Frame.SetParent(frame, env.UIHandler)
+end
+
 local function hideActionButton(button)
-	if not button then return end
-	button:Hide()
-	button:UnregisterAllEvents()
-	button:SetAttributeNoHandler('statehidden', true)
-	-- Shared dispatchers invoke buttons regardless of their own event
-	-- registrations, spreading hidden button taint to the dispatch loop.
-	-- Removal from the keyed dispatchers is taint-safe; the array-backed
-	-- ActionBarButtonEventsFrame is not, so slot changes still get through.
-	if ActionBarActionEventsFrame then
-		ActionBarActionEventsFrame:UnregisterFrame(button)
-	end
-	if ActionBarButtonUpdateFrame then
-		ActionBarButtonUpdateFrame:UnregisterFrame(button)
-	end
+	if not button then return end;
+	Frame.Hide(button)
+	Frame.UnregisterAllEvents(button)
+	Frame.SetAttributeNoHandler(button, 'statehidden', true)
+	purgeFromDispatchers(button)
 end
 
 local function NPE_LoadUI()
@@ -70,7 +60,7 @@ function env.UIHandler:HideBlizzard()
 		'ACTIONBAR_SHOWGRID';
 		'ACTIONBAR_HIDEGRID';
 	}) do
-		MainActionBar:UnregisterEvent(event)
+		Frame.UnregisterEvent(MainActionBar, event)
 	end
 
 	---------------------------------------------------------------
@@ -107,6 +97,12 @@ function env.UIHandler:HideBlizzard()
 	end
 	for i = 1, NUM_OVERRIDE_BUTTONS or 6 do
 		hideActionButton(_G['OverrideActionBarButton' .. i])
+	end
+	for i = 1, NUM_PET_ACTION_SLOTS or 10 do
+		hideActionButton(_G['PetActionButton' .. i])
+	end
+	for i = 1, NUM_POSSESS_SLOTS or 2 do
+		hideActionButton(_G['PossessButton' .. i])
 	end
 
 	---------------------------------------------------------------

--- a/ConsolePort_Config/View/Settings/DataProvider.lua
+++ b/ConsolePort_Config/View/Settings/DataProvider.lua
@@ -213,7 +213,6 @@ Settings:AddProvider(function(AddSetting, GetSortIndex)
 	for key, settings in db:For('Shared/Data', true) do
 		if settings.Bindings then
 			local datapoint, store = AddPreset(settings.Meta, MakePreset(settings.Bindings), false, key);
-			datapoint.index = #store;
 			datapoint.store = store;
 		end
 	end

--- a/ConsolePort_Config/View/Settings/Elements.lua
+++ b/ConsolePort_Config/View/Settings/Elements.lua
@@ -521,6 +521,14 @@ local function AddDoubleTooltipLine(tbl, left, right)
 	return tinsert(tbl, {left, right, 1, 1, 1, 1, 1, 1});
 end
 
+local function FindPreset(store, key)
+	for index, datapoint in ipairs(store) do
+		if ( datapoint.key == key and not datapoint.readonly ) then
+			return index, datapoint;
+		end
+	end
+end
+
 function BindingPresetIcon:OnIconChanged(result, saveResult)
 	self.NormalTexture:SetAlpha(not result and 0.25 or 1)
 	self.NormalTexture:SetTexture(result or CPAPI.GetAsset([[Textures\Button\EmptyIcon]]))
@@ -644,8 +652,10 @@ function BindingPreset:Rename(old, new, data)
 	db.Shared:CollectCharacterGarbage()
 	data.key, data.meta = new, meta;
 
-	local object = data.store[data.index];
-	object.key, object.meta = new, meta;
+	local _, object = FindPreset(data.store, old)
+	if object then
+		object.key, object.meta = new, meta;
+	end
 
 	env:TriggerEvent('Settings.OnDirty')
 end
@@ -656,7 +666,10 @@ function BindingPreset:Delete(data)
 
 	if db.Shared:RemoveData(data.key, 'Bindings') then
 		CPAPI.Log('Preset %s has been deleted.', data.meta.Name)
-		tremove(data.store, data.index)
+		local index = FindPreset(data.store, data.key)
+		if index then
+			tremove(data.store, index)
+		end
 		db.Shared:CollectCharacterGarbage()
 		env:TriggerEvent('Settings.OnDirty')
 	end
@@ -699,7 +712,6 @@ function BindingPreset:Data(datapoint)
 		preset   = datapoint.preset;
 		readonly = datapoint.readonly;
 		store    = datapoint.store;
-		index    = datapoint.index;
 		device   = datapoint.device;
 	};
 end
@@ -740,7 +752,6 @@ function BindingPresetAdd:OnAdded(icon, _, name)
 	entry.Meta = MakePresetMeta(name, icon)
 
 	local dp, store = data.add(entry.Meta, data.make(entry.Bindings), false, name)
-	dp.index = #store;
 	dp.store = store;
 
 	env:TriggerEvent('Settings.OnDirty')


### PR DESCRIPTION
**Look up binding presets by key instead of stale index.** Preset datapoints stored their position in the settings list at build time. `Delete` removed from the list without reindexing and `Rename` wrote into `store[index]`, so after the first delete in a session every later preset pointed one slot off: a second delete hid the wrong preset from the list, and a rename after a delete relabeled the next preset with the renamed key, after which deleting that entry removed the renamed preset's saved bindings. Find the datapoint by key (skipping the read-only device presets, which can share a name with a user preset) and drop the stored index.

**Harden the Blizzard bar hiders.** All frame operations go through `GetFrameMetatable().__index` so no Blizzard Lua override (`HideOverride`, `SetPointOverride`) can be hit by accident; `isShownExternal` is purged unconditionally; hidden buttons are removed from `ActionBarActionEventsFrame.frames` and `ActionBarButtonUpdateFrame.frames` with `CPAPI.Purge`, which rehashes the table so no dead node is left behind; override, pet and possess buttons are disarmed on both Retail and Classic. `CPAPI.Purge` accepts non-string keys by probing a string sentinel dropped by the same rehash; string-key behaviour is unchanged.